### PR TITLE
Use `call` instead of `link`

### DIFF
--- a/data/flows/replace_card.yml
+++ b/data/flows/replace_card.yml
@@ -12,7 +12,8 @@ flows:
         next:
           - if: slots.confirm_correct_card
             then:
-              - link: replace_eligible_card
+              - call: replace_eligible_card
+                next: END
           - else:
               - action: utter_relevant_card_not_linked
                 next: END


### PR DESCRIPTION
## Description

By using a `call` instead of a `link`, the bot is able to extract the slot `replacement_reason` from the sentence `I lost my card`