### PR TITLE
Update README & Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,36 @@ help:
 
 .EXPORT_ALL_VARIABLES:
 
+# ---------------------------------------------------
+# rasa based targets
+
+rasa-test: .EXPORT_ALL_VARIABLES
+	rasa test e2e e2e_tests
+
+rasa-run: .EXPORT_ALL_VARIABLES
+	rasa inspect --debug
+
+rasa-train: .EXPORT_ALL_VARIABLES
+	rasa train -c config.yml -d domain --data data
+
+rasa-actions:
+	rasa run actions
+
+rasa-test-passing: .EXPORT_ALL_VARIABLES
+	rasa test e2e e2e_tests/passing
+
+rasa-test-flaky: .EXPORT_ALL_VARIABLES
+	rasa test e2e e2e_tests/flaky
+
+rasa-test-failing: .EXPORT_ALL_VARIABLES
+	rasa test e2e e2e_tests/failing
+
+rasa-test-one: .EXPORT_ALL_VARIABLES
+	rasa test e2e $(target) --debug
+
+# ---------------------------------------------------
+# poetry based targets
+
 install:
 	poetry install
 

--- a/README.md
+++ b/README.md
@@ -170,37 +170,34 @@ and run end-to-end tests.
 
 > [!IMPORTANT]
 > To build, run, and explore the bot's features, you need Rasa Pro license. You also 
-> need access to the `rasa-plus` Python package, which requires authentication with 
-> our artifact repository. For detailed instructions on the authentication process,
+> need access to the `rasa-pro` Python package. For installation instructions
 > please refer our documentation [here](https://rasa.com/docs/rasa-pro/installation/python/installation).
 
 > [!NOTE]
-> If you want to use a different version of `rasa` or `rasa-plus`, you can 
+> If you install with poetry and you want to use a different version of `rasa-pro`, you can 
 > change the versions in the [pyproject.toml](./pyproject.toml) file.
 
 Prerequisites:
 - rasa pro license
-- being authenticated with our artifact registry
-- [poetry](https://python-poetry.org/docs/#installation) (1.8.2), e.g. using 
-  `poetry self update`
 - python (3.10.12), e.g. using [pyenv](https://github.com/pyenv/pyenv) 
   `pyenv install 3.10.12`
-- set up and running [Duckling](https://github.com/facebook/duckling) server
+- Some flows require to set up and run [Duckling](https://github.com/facebook/duckling) server
 
-After you cloned the repository and are authenticated, follow the installation steps:
+After you cloned the repository, follow these installation steps:
 
 1. Locate to the cloned repo:
    ```
-   cd demo-flows
+   cd rasa-calm-demo
    ```
 2. Set the python environment with `pyenv` or any other tool that gets you the right 
    python version
    ```
    pyenv local 3.10.12
    ```
-3. Install the dependencies with `poetry`
+3. Install the dependencies with `pip`
    ```
-   poetry install
+   pip install uv
+   uv pip install rasa-pro --extra-index-url=https://europe-west3-python.pkg.dev/rasa-releases/rasa-pro-python/simple/
    ```
 4. Create an environment file `.env` in the root of the project with the following 
    content:
@@ -214,7 +211,7 @@ After you cloned the repository and are authenticated, follow the installation s
 
 To train a model use `make` command for simplicity:
 ```commandline
-make train
+make rasa-train
 ```
 which is a shortcut for:
 ```commandline
@@ -229,7 +226,7 @@ Before interacting with your assistant, start the action server to enable the
 assistant to perform custom actions located in the `actions` directory. Start the 
 action server with the `make` command:
 ```commandline
-make actions
+make rasa-actions
 ```
 which is a shortcut for:
 ```commandline
@@ -238,13 +235,15 @@ rasa run actions
 
 Once the action server is started, you have two options to interact with your trained
 assistant:
-1. **CLI-based interaction** using rasa shell:
+
+1. **GUI-based interaction** using rasa inspector:
 ```commandline
-rasa shell
+rasa inspect --debug
 ```
-2. **GUI-based interaction** using rasa inspector:
+
+2. **CLI-based interaction** using rasa shell:
 ```commandline
-rasa inspect
+rasa shell --debug
 ```
 
 ### Running e2e test
@@ -264,24 +263,24 @@ failing tests, or a single specific test.
 
 To run **all the tests** you can use the `make` command:
 ```commandline
-make test
+make rasa-test
 ```
 or
 ```commandline
-run rasa test e2e e2e_tests
+rasa test e2e e2e_tests
 ```
 
 ------
 
 To run **passing/failing/flaky** tests you can use the `make` command:
 ```commandline
-make test-passing
+make rasa-test-passing
 ```
 ```commandline
-make test-failing
+make rasa-test-failing
 ```
 ```commandline
-make test-flaky
+make rasa-test-flaky
 ```
 or
 ```commandline
@@ -303,7 +302,7 @@ export target=e2e_tests/path/to/a/target/test.yml
 ```
 and then run:
 ```commandline
-make test-one
+make rasa-test-one
 ```
 or
 ```commandline


### PR DESCRIPTION
## Description

- remove all references to rasa-plus
- remove mention of authentication with registry. This is no longer needed.
- remove the need for poetry (Makefile still supports it, but it should not be required)
- provide alternative Makefile targets, without poetry