### PR TITLE
Slot Management rc1-QA bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dmypy.json
 models/
 .config/
 .keras/
+prompts/
+tests/

--- a/actions/order_pizza.py
+++ b/actions/order_pizza.py
@@ -51,7 +51,8 @@ class ActionCorrectOrderDetails(Action):
         )
         return [SlotSet("confirmation_order", None), SlotSet("correct_order", True)]
 
-class ActionShowVacancie(Action):
+
+class ActionShowVacancies(Action):
 
     def name(self) -> str:
         return "action_show_vacancies"
@@ -73,3 +74,16 @@ class ActionShowVacancie(Action):
                 text="We don't have any vacancies at the moment in that department. Please check back later."
             )
         return []
+
+
+class ActionCorrectAddress(Action):
+
+        def name(self) -> str:
+            return "action_correct_address"
+
+        def run(self, dispatcher: CollectingDispatcher,
+                tracker: Tracker, domain: Dict[str, Any]):
+            dispatcher.utter_message(
+                text="I'm sorry about that. Let's correct your address. Please confirm your new address?"
+            )
+            return [SlotSet("address", None)]

--- a/config.yml
+++ b/config.yml
@@ -26,7 +26,7 @@ pipeline:
   timezone: "Europe/Berlin"
   timeout: 3
 - name: NLUCommandAdapter
-- name: LLMCommandGenerator
+- name: SingleStepLLMCommandGenerator
   llm:
     model_name: gpt-4
     request_timeout: 7

--- a/data/flows/nlu.yml
+++ b/data/flows/nlu.yml
@@ -202,6 +202,14 @@ nlu:
         - Actually, can i get a [diavola](pizza_type) instead.
         - Actually, can i get a [quattro formaggi](pizza_type) instead.
 
+  - intent: correct_address
+    examples: |
+      - I actually want to change the delivery address to 13 Pine Road.
+      - actually can i get the pizza delivered to 13 Pine Road.
+      - I made a mistake and need to update my delivery address first to 43 Elm Street.
+      - Send the pizza to 25 Maple Avenue instead.
+      - I need to update the delivery address to 59 Oak Drive.
+
   - intent: correct_payment_option
     examples: |
       - Can I pay with credit card instead?

--- a/data/flows/nlu.yml
+++ b/data/flows/nlu.yml
@@ -119,7 +119,7 @@ nlu:
       - Remove an entry from my contact list.
       - Help me delete a contact permanently.
 
-  - intent: inform_pizza
+  - intent: request_pizza
     examples: |
       - Can i get a pizza please?
       - I would like to order a pizza.
@@ -129,6 +129,25 @@ nlu:
       - I want to order a [hawaiian](pizza_type) pizza.
       - I would like to order a [diavola](pizza_type) pizza.
       - I would like to order a [quattro formaggi](pizza_type) pizza.
+
+  - intent: inform_pizza_type
+    examples: |
+      - [margherita](pizza_type)
+      - [pepperoni](pizza_type)
+      - [vegetarian](pizza_type)
+      - [hawaiian](pizza_type)
+      - [diavola](pizza_type)
+      - [quattro formaggi](pizza_type)
+      - a [margherita](pizza_type) pizza
+      - a [pepperoni](pizza_type) pizza
+      - a [vegetarian](pizza_type) pizza
+      - a [hawaiian](pizza_type) pizza
+      - a [diavola](pizza_type) pizza
+      - a [quattro formaggi](pizza_type) and a [margherita](pizza_type) pizza
+      - a [quattro formaggi](pizza_type) and a [pepperoni](pizza_type) pizza
+      - a [quattro formaggi](pizza_type) and a [vegetarian](pizza_type) pizza
+      - a [quattro formaggi](pizza_type) and a [hawaiian](pizza_type) pizza
+      - a [quattro formaggi](pizza_type) and a [diavola](pizza_type) pizza
 
   - intent: inform_address
     examples: |
@@ -145,22 +164,6 @@ nlu:
       - [2](number) please
       - [3](number) pizzas
       - [4](number) pizzas
-
-  - intent: ask_availability
-    examples: |
-      - Do you have any pizzas left?
-      - Are there any [diavola](pizza_type) pizzas in stock?
-      - Can I still order a [margherita](pizza_type) pizza?
-      - Are there any pizzas available for delivery?
-      - Can I order a pizza now?
-      - Do you have any pizzas available for delivery?
-      - Can I still get a pizza delivered?
-      - Are there any pizzas left for delivery?
-      - Can I order a pizza for delivery now?
-      - Do you have any [margherita](pizza_type) pizzas available for takeout?
-      - Can I still get a [pepperoni](pizza_type) pizza for takeout?
-      - Are there any pizzas left for takeout?
-      - Can I order a [diavola](pizza_type) pizza for takeout now?
 
   - intent: correct_order
     examples: |

--- a/data/flows/order_pizza.yml
+++ b/data/flows/order_pizza.yml
@@ -48,6 +48,7 @@ flows:
       - collect: address
       - collect: confirmation_order
         reset_after_flow_ends: False
+        ask_before_filling: True
 
   use_membership_points:
     if: False
@@ -71,6 +72,17 @@ flows:
         confidence_threshold: 0.5
     steps:
       - collect: correct_order
+      - call: fill_pizza_order
+
+  correct_address:
+    name: correct_address
+    description: user wants to correct the delivery address
+    nlu_trigger:
+    - intent:
+        name: correct_address
+        confidence_threshold: 0.7
+    steps:
+      - action: action_correct_address
       - call: fill_pizza_order
 
   job_vacancies:

--- a/data/flows/order_pizza.yml
+++ b/data/flows/order_pizza.yml
@@ -4,7 +4,7 @@ flows:
     description: user asks for a pizza
     nlu_trigger:
     - intent:
-        name: inform_pizza
+        name: request_pizza
         confidence_threshold: 0.5
     steps:
     - call: fill_pizza_order

--- a/domain/flows/order_pizza.yml
+++ b/domain/flows/order_pizza.yml
@@ -2,10 +2,10 @@ version: "3.1"
 
 intents:
   - greet
-  - inform_pizza
+  - request_pizza
+  - inform_pizza_type
   - inform_address
   - inform_num_pizza
-  - ask_availability
   - correct_order
   - correct_num_pizza
   - correct_pizza_type
@@ -15,7 +15,6 @@ intents:
 
 entities:
   - pizza_type
-  - address
   - department
 
 slots:

--- a/domain/flows/order_pizza.yml
+++ b/domain/flows/order_pizza.yml
@@ -9,6 +9,7 @@ intents:
   - correct_order
   - correct_num_pizza
   - correct_pizza_type
+  - correct_address
   - correct_payment_option
   - affirm
   - deny
@@ -125,3 +126,4 @@ actions:
   - action_check_points
   - action_ask_correct_order
   - action_show_vacancies
+  - action_correct_address

--- a/domain/flows/patterns.yml
+++ b/domain/flows/patterns.yml
@@ -10,9 +10,9 @@ responses:
   utter_ask_confirm_slot_correction:
     - text: "Do you want to update the {{ context.corrected_slots.keys()|join(', ') }}?"
       buttons:
-        - payload: yes
+        - payload: /SetSlots(confirm_slot_correction=true)
           title: "Yes"
-        - payload: no
+        - payload: /SetSlots(confirm_slot_correction=false)
           title: "No, please keep the previous information"
       metadata:
         rephrase: True

--- a/domain/nlu-based/restaurant.yml
+++ b/domain/nlu-based/restaurant.yml
@@ -39,8 +39,6 @@ slots:
     mappings:
     - type: from_entity
       entity: number
-      conditions:
-        - active_loop: restaurant_form
   restaurant_name:
     type: text
     mappings:
@@ -51,8 +49,6 @@ slots:
     mappings:
     - type: from_entity
       entity: time
-      conditions:
-        - active_loop: restaurant_form
 
 actions:
   - action_list_restaurants

--- a/e2e_tests/passing/corrections/user_cancels_correction.yml
+++ b/e2e_tests/passing/corrections/user_cancels_correction.yml
@@ -9,7 +9,7 @@ test_cases:
       - utter: utter_ask_transfer_money_final_confirmation
       - user: Ah wait I think I actually owe him 60
       - utter: utter_ask_confirm_slot_correction
-      - user: "No"
+      - user: /SetSlots(confirm_slot_correction=false)
       - utter: utter_not_corrected_previous_input
       - utter: utter_ask_transfer_money_final_confirmation
       - user: "Yes"

--- a/e2e_tests/passing/corrections/user_corrects_a_branching_slot.yml
+++ b/e2e_tests/passing/corrections/user_corrects_a_branching_slot.yml
@@ -11,7 +11,7 @@ test_cases:
       - utter: utter_ask_verify_account_sufficient_california_income
       - user: sorry, I need to correct the previous input
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
       - slot_was_set:
           - based_in_california

--- a/e2e_tests/passing/corrections/user_corrects_amount_of_money_in_the_next_message.yml
+++ b/e2e_tests/passing/corrections/user_corrects_amount_of_money_in_the_next_message.yml
@@ -15,7 +15,7 @@ test_cases:
       - utter: utter_ask_transfer_money_final_confirmation
       - user: Ah, scratch that, I meant 110$
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - slot_was_set:
           - transfer_money_amount_of_money: "110"
       - utter: utter_corrected_previous_input

--- a/e2e_tests/passing/corrections/user_corrects_mentioning_old_value_first.yml
+++ b/e2e_tests/passing/corrections/user_corrects_mentioning_old_value_first.yml
@@ -15,7 +15,7 @@ test_cases:
       - utter: utter_ask_transfer_money_final_confirmation
       - user: Ah, not 50, I meant 55
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - slot_was_set:
           - transfer_money_amount_of_money: "55"
       - utter: utter_corrected_previous_input

--- a/e2e_tests/passing/corrections/user_corrects_mentioning_old_value_last.yml
+++ b/e2e_tests/passing/corrections/user_corrects_mentioning_old_value_last.yml
@@ -11,7 +11,7 @@ test_cases:
       - utter: utter_ask_transfer_money_amount_of_money
       - user: Sorry, I meant to say Jimmy, not John
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - slot_was_set:
           - transfer_money_recipient: Jimmy
       - utter: utter_corrected_previous_input

--- a/e2e_tests/passing/corrections/user_corrects_recipient_in_the_next_message.yml
+++ b/e2e_tests/passing/corrections/user_corrects_recipient_in_the_next_message.yml
@@ -11,7 +11,7 @@ test_cases:
       - utter: utter_ask_transfer_money_amount_of_money
       - user: Sorry, I meant to say Joe
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - slot_was_set:
           - transfer_money_recipient: Joe
       - utter: utter_corrected_previous_input

--- a/e2e_tests/passing/corrections/user_corrects_recipient_late.yml
+++ b/e2e_tests/passing/corrections/user_corrects_recipient_late.yml
@@ -15,7 +15,7 @@ test_cases:
       - utter: utter_ask_transfer_money_final_confirmation
       - user:  Oh wait, I want to send it to James!
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - slot_was_set:
           - transfer_money_recipient: James
       - utter: utter_corrected_previous_input

--- a/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
+++ b/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
@@ -11,7 +11,7 @@ test_cases:
       - utter: utter_ask_payment_option
       - user: actually can i get 2 pizzas instead
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
       - utter: utter_ask_payment_option
 
@@ -27,7 +27,7 @@ test_cases:
       - utter: utter_ask_payment_option
       - user: actually can i get a margherita instead
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
       - utter: utter_ask_payment_option
 

--- a/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
+++ b/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
@@ -45,7 +45,7 @@ test_cases:
       - utter: utter_ask_user_name
       - user: actually can i pay with a credit card
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
       - utter: utter_ask_card_details
 

--- a/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
+++ b/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
@@ -31,6 +31,22 @@ test_cases:
       - utter: utter_corrected_previous_input
       - utter: utter_ask_payment_option
 
+#  - test_case: user_orders_pizza_stating_which_type_and_corrects_address_later
+#    steps:
+#      - user: I would like to order a diavola pizza.
+#      - utter: utter_ask_num_pizza
+#      - user: 1 please
+#      - utter: utter_ask_address
+#      - user: 30 Pine Road
+#      - utter: utter_confirm
+#      - user: /SetSlots(confirmation_order=True)
+#      - utter: utter_ask_payment_option
+#      - user: actually can i get the pizza delivered to 13 Pine Road.
+#      - utter: utter_ask_confirm_slot_correction
+#      - user: /SetSlots(confirm_slot_correction=true)
+#      - utter: utter_corrected_previous_input
+#      - utter: utter_ask_payment_option
+
   - test_case: user_orders_pizza_stating_which_type_and_corrects_payment_option_later
     steps:
       - user: I would like to order a diavola pizza.

--- a/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
+++ b/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
@@ -61,9 +61,8 @@ test_cases:
       - utter: utter_ask_payment_option
       - user: actually, i made a mistake and need to update my delivery address first.
       - bot: "I'm sorry about that. Let's correct your order. What would you like to change?"
-        # TODO: ideal place to test next buttons feature in e2e testing
+        # TODO: ideal place to assert planned buttons feature in e2e testing
       - user: /SetSlots(address=null)
-# FIXME: To uncomment once ATO-2553 is fixed
-#      - utter: utter_ask_address
-#      - user: 3 Pine Road
-#      - utter: utter_confirm
+      - utter: utter_ask_address
+      - user: 3 Pine Road
+      - utter: utter_confirm

--- a/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
+++ b/e2e_tests/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
@@ -13,6 +13,8 @@ test_cases:
       - utter: utter_ask_confirm_slot_correction
       - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
+      - utter: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
       - utter: utter_ask_payment_option
 
   - test_case: user_orders_pizza_stating_which_type_and_corrects_pizza_type_later
@@ -29,23 +31,28 @@ test_cases:
       - utter: utter_ask_confirm_slot_correction
       - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
+      - utter: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
       - utter: utter_ask_payment_option
 
-#  - test_case: user_orders_pizza_stating_which_type_and_corrects_address_later
-#    steps:
-#      - user: I would like to order a diavola pizza.
-#      - utter: utter_ask_num_pizza
-#      - user: 1 please
-#      - utter: utter_ask_address
-#      - user: 30 Pine Road
-#      - utter: utter_confirm
-#      - user: /SetSlots(confirmation_order=True)
-#      - utter: utter_ask_payment_option
-#      - user: actually can i get the pizza delivered to 13 Pine Road.
-#      - utter: utter_ask_confirm_slot_correction
-#      - user: /SetSlots(confirm_slot_correction=true)
-#      - utter: utter_corrected_previous_input
-#      - utter: utter_ask_payment_option
+  - test_case: user_orders_pizza_stating_which_type_and_corrects_address_later
+    steps:
+      - user: I would like to order a diavola pizza.
+      - utter: utter_ask_num_pizza
+      - user: 1 please
+      - utter: utter_ask_address
+      - user: 31 Pine Road
+      - utter: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+      - utter: utter_ask_payment_option
+      - user: wait, i meant to say the pizza should be delivered to 13 Pine Road.
+      - bot: "I'm sorry about that. Let's correct your address. Please confirm your new address?"
+      - utter: utter_ask_address
+      - user: 13 Pine Road
+      - utter: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+      - utter: utter_flow_continue_interrupted
+      - utter: utter_ask_payment_option
 
   - test_case: user_orders_pizza_stating_which_type_and_corrects_payment_option_later
     steps:
@@ -82,3 +89,6 @@ test_cases:
       - utter: utter_ask_address
       - user: 3 Pine Road
       - utter: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+      - utter: utter_flow_continue_interrupted
+      - utter: utter_ask_payment_option

--- a/e2e_tests/passing/corrections/user_corrects_string_slot.yml
+++ b/e2e_tests/passing/corrections/user_corrects_string_slot.yml
@@ -16,7 +16,7 @@ test_cases:
       - utter: utter_ask_add_contact_confirmation
       - user: Ah, please use Spidey as the name
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
       - utter: utter_ask_add_contact_confirmation
       - user: "yes"

--- a/e2e_tests/passing/corrections/user_corrects_twice_in_row.yml
+++ b/e2e_tests/passing/corrections/user_corrects_twice_in_row.yml
@@ -9,7 +9,7 @@ test_cases:
       - utter: utter_ask_confirm_slot_correction
       - user: damn, should be Alex
       - utter: utter_ask_confirm_slot_correction
-      - user: "Yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - slot_was_set:
           - transfer_money_recipient: Alex
       - utter: utter_corrected_previous_input

--- a/e2e_tests/passing/corrections/user_resets_a_slot_by_slot_name.yml
+++ b/e2e_tests/passing/corrections/user_resets_a_slot_by_slot_name.yml
@@ -9,7 +9,7 @@ test_cases:
       - utter: utter_ask_transfer_money_final_confirmation
       - user: I want to change the recipient
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
       - utter: utter_ask_transfer_money_recipient
       - user: Eliza

--- a/e2e_tests/passing/corrections/user_resets_a_slot_by_value.yml
+++ b/e2e_tests/passing/corrections/user_resets_a_slot_by_value.yml
@@ -7,7 +7,7 @@ test_cases:
       - utter: utter_ask_transfer_money_amount_of_money
       - user: Sorry, I didn't mean John
       - utter: utter_ask_confirm_slot_correction
-      - user: "yes"
+      - user: /SetSlots(confirm_slot_correction=true)
       - utter: utter_corrected_previous_input
       - utter: utter_ask_transfer_money_recipient
       - user: to Joe

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,13 +31,13 @@ develop = ["aiomisc (>=16.0,<17.0)", "coverage (!=4.3)", "coveralls", "nox", "py
 
 [[package]]
 name = "aiofiles"
-version = "23.2.1"
+version = "24.1.0"
 description = "File support for asyncio."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "aiofiles-23.2.1-py3-none-any.whl", hash = "sha256:19297512c647d4b27a2cf7c34caa7e405c0d60b5560618a29a9fe027b18b0107"},
-    {file = "aiofiles-23.2.1.tar.gz", hash = "sha256:84ec2218d8419404abcb9f0c02df3f34c6e0a68ed41072acfb1cef5cbc29051a"},
+    {file = "aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5"},
+    {file = "aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c"},
 ]
 
 [[package]]
@@ -466,17 +466,17 @@ numpy = [
 
 [[package]]
 name = "boto3"
-version = "1.34.130"
+version = "1.34.134"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.130-py3-none-any.whl", hash = "sha256:c163fb7135a94e7b8c8c478a44071c843f05e212fa4bec3105f8a437ecbf1bcb"},
-    {file = "boto3-1.34.130.tar.gz", hash = "sha256:b781d267dd5e7583966e05697f6bd45e2f46c01dc619ba0860b042963ee69296"},
+    {file = "boto3-1.34.134-py3-none-any.whl", hash = "sha256:342782c02ff077aae118c9c61179eed95c585831fba666baacc5588ff04aa6e1"},
+    {file = "boto3-1.34.134.tar.gz", hash = "sha256:f6d6e5b0c9ab022a75373fa16c01f0cd54bc1bb64ef3b6ac64ac7cedd56cbe9c"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.130,<1.35.0"
+botocore = ">=1.34.134,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -485,13 +485,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.130"
+version = "1.34.134"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.130-py3-none-any.whl", hash = "sha256:a3b36e9dac1ed31c4cb3a5c5e540a7d8a9b90ff1d17f87734e674154b41776d8"},
-    {file = "botocore-1.34.130.tar.gz", hash = "sha256:a242b3b0a836b14f308a309565cd63e88654cec238f9b73abbbd3c0526db4c81"},
+    {file = "botocore-1.34.134-py3-none-any.whl", hash = "sha256:45219e00639755f92569b29f8f279d5dde721494791412c1f7026a3779e8d9f4"},
+    {file = "botocore-1.34.134.tar.gz", hash = "sha256:e29c299599426ed16dd2d4c1e20eef784f96b15e1850ebbc59a3250959285b95"},
 ]
 
 [package.dependencies]
@@ -1222,41 +1222,42 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "faiss-cpu"
-version = "1.8.0"
+version = "1.8.0.post1"
 description = "A library for efficient similarity search and clustering of dense vectors."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "faiss-cpu-1.8.0.tar.gz", hash = "sha256:3ee1549491728f37b65267c192a94661a907154a8ae0546ad50a564b8be0d82e"},
-    {file = "faiss_cpu-1.8.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:134a064c7411acf7d1d863173a9d2605c5a59bd573639ab39a5ded5ca983b1b2"},
-    {file = "faiss_cpu-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ba8e6202d561ac57394c9d691ff17f8fa6eb9a077913a993fce0a154ec0176f1"},
-    {file = "faiss_cpu-1.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a66e9fa7b70556a39681f06e0652f4124c8ddb0a1924afe4f0e40b6924dc845b"},
-    {file = "faiss_cpu-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51aaef5a1255d0ea88ea7e52a2415f98c5dd2dd9cec10348d55136541eeec99f"},
-    {file = "faiss_cpu-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:38152761242870ec7019e0397cbd0ed0b0716562029ce41a71bb38448bd6d5bc"},
-    {file = "faiss_cpu-1.8.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:c9e6ad94b86626be1a0faff3e53c4ca169eba88aa156d7e90c5a2e9ba30558fb"},
-    {file = "faiss_cpu-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4601dbd81733bf1bc3bff690aac981289fb386dc8e60d0c4eec8a37ba6856d20"},
-    {file = "faiss_cpu-1.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa943d3b5e8c5c77cdd629d9c3c6f78d7da616e586fdd1b94aecbf2e5fa9ba06"},
-    {file = "faiss_cpu-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b644b366c3b239b34fa3e08bf65bfc78a24eda1e1ea5b2b6d9be3e8fc73d8179"},
-    {file = "faiss_cpu-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:f85ecf3514850f93985be238351f5a70736133cfae784b372640aa17c6343a1b"},
-    {file = "faiss_cpu-1.8.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:61abc0129a357ac00f17f5167f14dff41480de2cc852f306c3d4cd36b893ccbd"},
-    {file = "faiss_cpu-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b788186d6eb94e6333e1aa8bb6c84b66e967458ecdd1cee22e16f04c43ee674c"},
-    {file = "faiss_cpu-1.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5658d90a202c62e4a69c5b065785e9ddcaf6986cb395c16afed8dbe4c58c31a2"},
-    {file = "faiss_cpu-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d460a372efce547e53d3c47d2c2a8a90b186ad245969048c10c1d7a1e5cf21b"},
-    {file = "faiss_cpu-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:9e6520324f0a6764dd267b3c32c76958bf2b1ec36752950f6fab31a7295980a0"},
-    {file = "faiss_cpu-1.8.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fc44be179d5b7f690484ef0d0caf817fea2698a5275a0c7fb6cbf406e5b2e4d1"},
-    {file = "faiss_cpu-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bbd6f0bc2e1424a12dc7e19d2cc95b53124867966b21110d26f909227e7ed1f1"},
-    {file = "faiss_cpu-1.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06e7add0c8a06ce8fb0443c38fcaf49c45fb74527ea633b819e56452608e64f5"},
-    {file = "faiss_cpu-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b864e23c1817fa6cfe9bbec096fd7140d596002934f71aa89b196ffb1b9cd846"},
-    {file = "faiss_cpu-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:655433755845adbb6f0961e2f8980703640cb9faa96f1cd1ea190252149e0d0a"},
-    {file = "faiss_cpu-1.8.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:e81fc376a3bcda213ffb395dda1018c953ce927c587731ad582f4e6c2b225363"},
-    {file = "faiss_cpu-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8c6fa6b7eaf558307b4ab118a236e8d1da79a8685222928e4dd52e277dba144a"},
-    {file = "faiss_cpu-1.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:652f6812ef2e8b0f9b18209828c590bc618aca82e7f1c1b1888f52928258e406"},
-    {file = "faiss_cpu-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:304da4e0d19044374b63a5b6467028572eac4bd3f32bc9e8783d800a03fb1f02"},
-    {file = "faiss_cpu-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:cb475d3f25f08c97ac64dfe026f113e2aeb9829b206b3b046256c3b40dd7eb62"},
+    {file = "faiss_cpu-1.8.0.post1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:fd84721eb599aa1da19b1b36345bb8705a60bb1d2887bbbc395a29e3d36a1a62"},
+    {file = "faiss_cpu-1.8.0.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b78ff9079d15fd0f156bf5dd8a2975a8abffac1854a86ece263eec1500a2e836"},
+    {file = "faiss_cpu-1.8.0.post1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9de25c943d1789e35fe06a20884c88cd32aedbb1a33bb8da2238cdea7bd9633f"},
+    {file = "faiss_cpu-1.8.0.post1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:adae0f1b144e7216da696f14bc4991ca4300c94baaa59247c3d322588e661c95"},
+    {file = "faiss_cpu-1.8.0.post1-cp310-cp310-win_amd64.whl", hash = "sha256:00345290680a444a4b4cb2d98a3844bb5c401a2160fee547c7631d759fd2ec3e"},
+    {file = "faiss_cpu-1.8.0.post1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:8d4bade10cb63e9f9ff261751edd7eb097b1f4bf30be4d0d25d6f688559d795e"},
+    {file = "faiss_cpu-1.8.0.post1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:20bd43eca3b7d77e71ea56b7a558cc28e900d8abff417eb285e2d92e95d934d4"},
+    {file = "faiss_cpu-1.8.0.post1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8542a87743a7f94ac656fd3e9592ad57e58b04d961ad2fe654a22a8ca59defdb"},
+    {file = "faiss_cpu-1.8.0.post1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed46928de3dc20170b10fec89c54075a11383c2aaf4f119c63e0f6ae5a507d74"},
+    {file = "faiss_cpu-1.8.0.post1-cp311-cp311-win_amd64.whl", hash = "sha256:4fa5fc8ea210b919aa469e27d6687e50052db906e7fec3f2257178b1384fa18b"},
+    {file = "faiss_cpu-1.8.0.post1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:96aec0d08a3099883af3a9b6356cfe736e8bd879318a940a27e9d1ae6f33d788"},
+    {file = "faiss_cpu-1.8.0.post1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92b06147fa84732ecdc965922e8ef50dc7011ef8be65821ff4abb2118cb5dce0"},
+    {file = "faiss_cpu-1.8.0.post1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:709ef9394d1148aef70dbe890edbde8c282a4a2e06a8b69ab64f65e90f5ba572"},
+    {file = "faiss_cpu-1.8.0.post1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:327a9c30971bf72cd8392b15eb4aff5d898c453212eae656dfaa3ba555b9ca0c"},
+    {file = "faiss_cpu-1.8.0.post1-cp312-cp312-win_amd64.whl", hash = "sha256:8756f1d93faba56349883fa2f5d47fe36bb2f11f789200c6b1c691ef805485f2"},
+    {file = "faiss_cpu-1.8.0.post1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f4a3045909c447bf1955b70083891e80f2c87c5427f20cae25245e08ec5c9e52"},
+    {file = "faiss_cpu-1.8.0.post1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8842b7fc921ca1fafdb0845f2ba029e79df04eebae72ab135239f93478a9b7a2"},
+    {file = "faiss_cpu-1.8.0.post1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d5a9799634e32c3862d5436d1e78112ed9a38f319e4523f5916e55d86adda8f"},
+    {file = "faiss_cpu-1.8.0.post1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a70923b0fbbb40f647e20bcbcbfd472277e6d84bb23ff12d2a94b6841806b55"},
+    {file = "faiss_cpu-1.8.0.post1-cp38-cp38-win_amd64.whl", hash = "sha256:ce652df3c4dd50c88ac9235d072f30ce60694dc422c5f523bbbcab320e8f3097"},
+    {file = "faiss_cpu-1.8.0.post1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:83ef04b17b19189dd6601a941bdf4bfa9de0740dbcd80305aeba51a1b1955f80"},
+    {file = "faiss_cpu-1.8.0.post1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c50c8697077470ede7f1939ef8dc8a846ec19cf1893b543f6b67f9af03b0a122"},
+    {file = "faiss_cpu-1.8.0.post1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98ce428a7a67fe5c64047280e5e12a8dbdecf7002f9d127b26cf1db354e9fe76"},
+    {file = "faiss_cpu-1.8.0.post1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f3b36b80380bae523e3198cfb4a137867055945ce7bf10d18fe9f0284f2fb47"},
+    {file = "faiss_cpu-1.8.0.post1-cp39-cp39-win_amd64.whl", hash = "sha256:4fcc67a2353f08a20c1ab955de3cde14ef3b447761b26244a5aa849c15cbc9b3"},
+    {file = "faiss_cpu-1.8.0.post1.tar.gz", hash = "sha256:5686af34414678c3d49c4fa8d774df7156e9cb48d7029071e56230e74b01cc13"},
 ]
 
 [package.dependencies]
-numpy = "*"
+numpy = ">=1.0,<2.0"
+packaging = "*"
 
 [[package]]
 name = "faker"
@@ -1289,13 +1290,13 @@ requests = ">=2.0"
 
 [[package]]
 name = "filelock"
-version = "3.15.3"
+version = "3.15.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.15.3-py3-none-any.whl", hash = "sha256:0151273e5b5d6cf753a61ec83b3a9b7d8821c39ae9af9d7ecf2f9e2f17404103"},
-    {file = "filelock-3.15.3.tar.gz", hash = "sha256:e1199bf5194a2277273dacd50269f0d87d0682088a3c561c15674ea9005d8635"},
+    {file = "filelock-3.15.4-py3-none-any.whl", hash = "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7"},
+    {file = "filelock-3.15.4.tar.gz", hash = "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb"},
 ]
 
 [package.extras]
@@ -1481,13 +1482,13 @@ files = [
 
 [[package]]
 name = "fsspec"
-version = "2024.6.0"
+version = "2024.6.1"
 description = "File-system specification"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fsspec-2024.6.0-py3-none-any.whl", hash = "sha256:58d7122eb8a1a46f7f13453187bfea4972d66bf01618d37366521b1998034cee"},
-    {file = "fsspec-2024.6.0.tar.gz", hash = "sha256:f579960a56e6d8038a9efc8f9c77279ec12e6299aa86b0769a7e9c46b94527c2"},
+    {file = "fsspec-2024.6.1-py3-none-any.whl", hash = "sha256:3cb443f8bcd2efb31295a5b9fdb02aee81d8452c80d28f97a6d0959e6cee101e"},
+    {file = "fsspec-2024.6.1.tar.gz", hash = "sha256:fad7d7e209dd4c1208e3bbfda706620e0da5142bebbd9c384afb95b07e798e49"},
 ]
 
 [package.extras]
@@ -3797,13 +3798,13 @@ files = [
 
 [[package]]
 name = "portalocker"
-version = "2.8.2"
+version = "2.10.0"
 description = "Wraps the portalocker recipe for easy usage"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "portalocker-2.8.2-py3-none-any.whl", hash = "sha256:cfb86acc09b9aa7c3b43594e19be1345b9d16af3feb08bf92f23d4dce513a28e"},
-    {file = "portalocker-2.8.2.tar.gz", hash = "sha256:2b035aa7828e46c58e9b31390ee1f169b98e1066ab10b9a6a861fe7e25ee4f33"},
+    {file = "portalocker-2.10.0-py3-none-any.whl", hash = "sha256:48944147b2cd42520549bc1bb8fe44e220296e56f7c3d551bc6ecce69d9b0de1"},
+    {file = "portalocker-2.10.0.tar.gz", hash = "sha256:49de8bc0a2f68ca98bf9e219c81a3e6b27097c7bf505a87c5a112ce1aaeb9b81"},
 ]
 
 [package.dependencies]
@@ -4771,13 +4772,13 @@ fire = "*"
 
 [[package]]
 name = "rasa-pro"
-version = "3.9.0rc1"
+version = "3.9.0rc2"
 description = "State-of-the-art open-core Conversational AI framework for Enterprises that natively leverages generative AI for effortless assistant development."
 optional = false
 python-versions = ">=3.8.1,<3.11"
 files = [
-    {file = "rasa_pro-3.9.0rc1-py3-none-any.whl", hash = "sha256:95328a73c8e5ab307a287a72f1bb507d690f8088ba1bdc685fdbc051b6bce289"},
-    {file = "rasa_pro-3.9.0rc1.tar.gz", hash = "sha256:1f2457a7878871fced66ce69227b1b0a1808b6d396bc6c9a1818fd38fadba0da"},
+    {file = "rasa_pro-3.9.0rc2-py3-none-any.whl", hash = "sha256:aa3b47d997b81d00046eb5d710014001c223f4137bbef641043974586b38f5a8"},
+    {file = "rasa_pro-3.9.0rc2.tar.gz", hash = "sha256:86c0e376da5982ba9cf53be5feca7e5e38836f6f0d32c9b67917f26d779c6e5c"},
 ]
 
 [package.dependencies]
@@ -4855,7 +4856,7 @@ pyyaml = ">=6.0"
 qdrant-client = ">=1.9.0,<2.0.0"
 questionary = ">=1.10.0,<2.1.0"
 randomname = ">=0.2.1,<0.3.0"
-rasa-sdk = "3.9.0rc1"
+rasa-sdk = "3.9.0rc2"
 redis = ">=4.6.0,<6.0"
 regex = ">=2022.10.31,<2022.11"
 requests = ">=2.31.0,<2.32.0"
@@ -4914,13 +4915,13 @@ reference = "rasa-pro"
 
 [[package]]
 name = "rasa-sdk"
-version = "3.9.0rc1"
+version = "3.9.0rc2"
 description = "Open source machine learning framework to automate text- and voice-based conversations: NLU, dialogue management, connect to Slack, Facebook, and more - Create chatbots and voice assistants"
 optional = false
 python-versions = "<3.11,>=3.8"
 files = [
-    {file = "rasa_sdk-3.9.0rc1-py3-none-any.whl", hash = "sha256:8c2755a0b002c814d9093a8a1c98a2ee0500c95aea478c2f5df23fa7431fe3c7"},
-    {file = "rasa_sdk-3.9.0rc1.tar.gz", hash = "sha256:ff9433112fcb2a54bd07699fa1cd46937ccf90a7b5c686a1899be68f3e04190e"},
+    {file = "rasa_sdk-3.9.0rc2-py3-none-any.whl", hash = "sha256:b411b2dd57e1ce56ac7b7ee0a6a34d81beae9e40ac414f1cf6783ac8388a4f2b"},
+    {file = "rasa_sdk-3.9.0rc2.tar.gz", hash = "sha256:e41eeb25570a9d0a38cd3e422e1f2baf84f60a5bf3f1b72db6904c86b8cb8c38"},
 ]
 
 [package.dependencies]
@@ -4943,13 +4944,13 @@ websockets = ">=10.0,<12.0"
 
 [[package]]
 name = "redis"
-version = "5.0.6"
+version = "5.0.7"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-5.0.6-py3-none-any.whl", hash = "sha256:c0d6d990850c627bbf7be01c5c4cbaadf67b48593e913bb71c9819c30df37eee"},
-    {file = "redis-5.0.6.tar.gz", hash = "sha256:38473cd7c6389ad3e44a91f4c3eaf6bcb8a9f746007f29bf4fb20824ff0b2197"},
+    {file = "redis-5.0.7-py3-none-any.whl", hash = "sha256:0e479e24da960c690be5d9b96d21f7b918a98c0cf49af3b6fafaa0753f93a0db"},
+    {file = "redis-5.0.7.tar.gz", hash = "sha256:8f611490b93c8109b50adc317b31bfd84fff31def3475b92e7e80bf39f48175b"},
 ]
 
 [package.dependencies]
@@ -5373,13 +5374,13 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.10.1"
+version = "0.10.2"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">= 3.8"
+python-versions = ">=3.8"
 files = [
-    {file = "s3transfer-0.10.1-py3-none-any.whl", hash = "sha256:ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d"},
-    {file = "s3transfer-0.10.1.tar.gz", hash = "sha256:5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19"},
+    {file = "s3transfer-0.10.2-py3-none-any.whl", hash = "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"},
+    {file = "s3transfer-0.10.2.tar.gz", hash = "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6"},
 ]
 
 [package.dependencies]
@@ -5580,13 +5581,13 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "setuptools"
-version = "70.1.0"
+version = "70.1.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.1.0-py3-none-any.whl", hash = "sha256:d9b8b771455a97c8a9f3ab3448ebe0b29b5e105f1228bba41028be116985a267"},
-    {file = "setuptools-70.1.0.tar.gz", hash = "sha256:01a1e793faa5bd89abc851fa15d0a0db26f160890c7102cd8dce643e886b47f5"},
+    {file = "setuptools-70.1.1-py3-none-any.whl", hash = "sha256:a58a8fde0541dab0419750bcc521fbdf8585f6e5cb41909df3a472ef7b81ca95"},
+    {file = "setuptools-70.1.1.tar.gz", hash = "sha256:937a48c7cdb7a21eb53cd7f9b59e525503aa8abaf3584c730dc5f7a5bec3a650"},
 ]
 
 [package.extras]
@@ -5651,13 +5652,13 @@ tqdm = ">=2.0"
 
 [[package]]
 name = "slack-sdk"
-version = "3.29.0"
+version = "3.30.0"
 description = "The Slack API Platform SDK for Python"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "slack_sdk-3.29.0-py2.py3-none-any.whl", hash = "sha256:1857300b9bdd5cd43eb527a0dd8c6415aa0623cd76e153bf167e93968efd5121"},
-    {file = "slack_sdk-3.29.0.tar.gz", hash = "sha256:a6ad02fd23a7c70ded7e48e0fe317e269820e64e55069699cc75d64fb2ebf5a1"},
+    {file = "slack_sdk-3.30.0-py2.py3-none-any.whl", hash = "sha256:42d1c95f7159887ddb4841d461fbe7ab0c48e4968f3cd44eaaa792cf109f4425"},
+    {file = "slack_sdk-3.30.0.tar.gz", hash = "sha256:001a4013698d3f244645add49c80adf8addc3a6bf633193848f7cbae3d387e0b"},
 ]
 
 [package.extras]
@@ -6003,13 +6004,13 @@ files = [
 
 [[package]]
 name = "tenacity"
-version = "8.4.1"
+version = "8.4.2"
 description = "Retry code until it succeeds"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tenacity-8.4.1-py3-none-any.whl", hash = "sha256:28522e692eda3e1b8f5e99c51464efcc0b9fc86933da92415168bc1c4e2308fa"},
-    {file = "tenacity-8.4.1.tar.gz", hash = "sha256:54b1412b878ddf7e1f1577cd49527bad8cdef32421bd599beac0c6c3f10582fd"},
+    {file = "tenacity-8.4.2-py3-none-any.whl", hash = "sha256:9e6f7cf7da729125c7437222f8a522279751cdfbe6b67bfe64f75d3a348661b2"},
+    {file = "tenacity-8.4.2.tar.gz", hash = "sha256:cd80a53a79336edba8489e767f729e4f391c896956b57140b5d7511a64bbd3ef"},
 ]
 
 [package.extras]
@@ -7270,4 +7271,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "e70ddce79134db193af98f2f9df29b155fb3a5ac089d21171a4e2ba6d4bf4eaa"
+content-hash = "0227cdc558f0ff0f2ffed0b2da04e7ab5642c463872ec1af7314c8a9f1ec094d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ priority = "supplemental"
 python = ">=3.8.1,<3.11"
 
 [tool.poetry.dependencies.rasa-pro]
-version = "3.9.0rc1"
+version = "3.9.0rc2"
 allow-prereleases = true
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Description

Addressed a number of bugfixes that were released in `3.9.0rc2`, including updating the `rc` version:
- Uncommented lines in E2E test case `user_orders_pizza_stating_which_type_and_corrects_order_details_later` after fixing [ATO-2553](https://rasahq.atlassian.net/browse/ATO-2553)
- Use /SetSlots button syntax to update correction confirmation slot
- Prevent NLUCommander from setting DM1 slots


## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)


[ATO-2553]: https://rasahq.atlassian.net/browse/ATO-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ