### PR TITLE
add e2e tests with metadata

### DIFF
--- a/actions/search_hotel.py
+++ b/actions/search_hotel.py
@@ -32,4 +32,7 @@ class SearchHotelAction(Action):
                 returned through the endpoint
         """
 
-        return [SlotSet("hotel_name", "Shadyside Inn"), SlotSet("hotel_average_rating", 2)]
+        metadata = tracker.latest_message.get("metadata", {})
+        hotel_name = metadata.get("hotel_name", "Shadyside Inn")
+        hotel_average_rating = metadata.get("hotel_average_rating", 2)
+        return [SlotSet("hotel_name", hotel_name), SlotSet("hotel_average_rating", hotel_average_rating)]

--- a/e2e_tests/passing/happy_path/user_search_hotel.yml
+++ b/e2e_tests/passing/happy_path/user_search_hotel.yml
@@ -1,0 +1,43 @@
+metadata:
+  - german_hotel_search:
+      hotel_name: Steigenberger Hotel
+      hotel_average_rating: 3
+  - uk_hotel_search:
+      hotel_name: Britannia International Hotel
+      hotel_average_rating: 4
+  - updated_rating:
+      hotel_average_rating: 8.5
+
+test_cases:
+  - test_case: user searches for hotels with no metadata
+    steps:
+      - user: I want to search for hotels
+      - slot_was_set:
+          - hotel_name: "Shadyside Inn"
+          - hotel_average_rating: 2
+      - utter: utter_hotel_inform_rating
+  - test_case: user searches for hotels with test_case metadata
+    metadata: german_hotel_search
+    steps:
+      - user: I want to search for hotels
+      - slot_was_set:
+          - hotel_name: "Steigenberger Hotel"
+          - hotel_average_rating: 3
+      - utter: utter_hotel_inform_rating
+  - test_case: user searches for hotels with user step metadata
+    steps:
+      - user: I want to search for hotels
+        metadata: uk_hotel_search
+      - slot_was_set:
+          - hotel_name: "Britannia International Hotel"
+          - hotel_average_rating: 4
+      - utter: utter_hotel_inform_rating
+  - test_case: user searches for hotels with test_case and user step metadata
+    metadata: german_hotel_search
+    steps:
+      - user: I want to search for hotels
+        metadata: updated_rating
+      - slot_was_set:
+          - hotel_name: "Steigenberger Hotel"
+          - hotel_average_rating: 8.5
+      - utter: utter_hotel_inform_rating


### PR DESCRIPTION
## Description
Adds e2e tests with metadata
<img width="1138" alt="Screenshot 2024-07-01 at 10 12 14" src="https://github.com/RasaHQ/rasa-calm-demo/assets/23738768/ca35de25-b4ac-4acc-ab51-3d507b85bfde">


## TODOs
[ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)
