### PR TITLE
Update README for qdrant depency installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,9 +133,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Rasa
 .rasa/
 models/
 .config/
 .keras/
 prompts/
 tests/
+qdrant_storage/

--- a/README.md
+++ b/README.md
@@ -289,9 +289,10 @@ After you cloned the repository, follow these installation steps:
          qdrant/qdrant
       ```
    - Upload data to Qdrant
-      - Create a virtual environment for the upload:
+      - In your virtual environment where Rasa Pro is installed, also install these dependencies:
          ```
-         pip install -r qdrant-requirements.txt
+         pip install uv
+         uv pip install -r qdrant-requirements.txt
          ```
       - Ingest documents from SQUAD dataset (modify the script if qdrant isn't running locally!)
          ```


### PR DESCRIPTION
Updated the instructions for qdrant dependencies installation:
- Explicitly specify to  install qdrant dependencies in same virtual env as where rasa pro is installed
- use uv

Why:
- Doing it in a separate environment is also possible, but then:
  - qdrant-requirement.txt must be updated to include langchain, else you cannot run the upload script
  - the rasa environment must be updated to include sentence-transformers, else you can not train
- without using uv, pip gives error messages about conflicting packages.