### PR TITLE
Removed unnecessary test for chitchat response

### DIFF
--- a/e2e_tests/passing/happy_path/user_fills_resetting_slot.yml
+++ b/e2e_tests/passing/happy_path/user_fills_resetting_slot.yml
@@ -19,5 +19,4 @@ test_cases:
       - slot_was_not_set:
         - based_in_california
       - utter: utter_can_do_something_else
-      - user: Bye then
-      - utter: utter_goodbye
+


### PR DESCRIPTION


## Description

Removed unnecessary test for chit chat response in a happy path test. The reason to do this is to make this test useable for testing multistep prompting which cannot issue a chitchat response.

## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)
