### PR TITLE
[ENG-1207] Add links to pattern_human_handoff

### DIFF
--- a/actions/action_increase_clarification_count.py
+++ b/actions/action_increase_clarification_count.py
@@ -1,0 +1,23 @@
+from rasa_sdk.events import SlotSet
+from rasa_sdk import Action, Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+
+class ActionIncreaseClarificationCount(Action):
+    """Action which clarifies which flow to start."""
+
+    def name(self) -> str:
+        """Return the flow name."""
+        return "action_increase_clarification_count"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: dict
+    ) -> list:
+        attempts = tracker.get_slot("clarification_count")
+        if not attempts:
+            attempts = 0
+
+        return [SlotSet("clarification_count", attempts + 1)]

--- a/actions/authenticate_user.py
+++ b/actions/authenticate_user.py
@@ -13,13 +13,16 @@ class ActionAuthenticateUser(Action):
         # Retrieve the user credentials from slots
         user_name = tracker.get_slot("user_name")
         user_password = tracker.get_slot("user_password")
+        attempts = tracker.get_slot("login_failed_attempts")
+        if not attempts:
+            attempts = 0
 
         # Dummy authentication.
         # Placeholder for user authentication, in real scenarios the username and
         # password should be checked against a database.
-        authenticated = True
+        authenticated = not (user_name == "John" and user_password == "1234")
 
         if authenticated:
             return [SlotSet("is_user_logged_in", True)]
         else:
-            return [SlotSet("is_user_logged_in", False)]
+            return [SlotSet("is_user_logged_in", False), SlotSet("login_failed_attempts", attempts + 1)]

--- a/data/flows/authenticate_user.yml
+++ b/data/flows/authenticate_user.yml
@@ -15,9 +15,16 @@ flows:
         description: "The password of the user."
       - action: action_authenticate_user
         next:
+        - if: slots.login_failed_attempts >= 3
+          then:
+            - action: utter_authentication_failed_multiple_times
+              next: END
         - if: not slots.is_user_logged_in
           then:
             - action: utter_authentication_failed
+            - set_slots:
+                - user_name: null
+                - user_password: null
               next: ask_user_credentials
         - else:
             - action: utter_authentication_successful

--- a/data/flows/check_portfolio.yml
+++ b/data/flows/check_portfolio.yml
@@ -3,7 +3,13 @@ flows:
     description: "Check the user's investment portfolio, including stocks, bonds, and mutual funds."
     steps:
       - call: authenticate_user
-      - collect: portfolio_type
+        next:
+          - if: slots.login_failed_attempts >= 3
+            then:
+              - link: pattern_human_handoff
+          - else: collect_portfolio_type
+      - id: collect_portfolio_type
+        collect: portfolio_type
         description: "The type of portfolio, for example: stocks, bonds or mutual_funds."
       - action: action_check_portfolio_exists
         next:

--- a/data/flows/patterns.yml
+++ b/data/flows/patterns.yml
@@ -52,3 +52,17 @@ flows:
     steps:
       - action: utter_can_do_something_else
       - action: action_reset_routing
+
+  pattern_clarification:
+    description: Conversation repair flow for handling ambiguous requests that could match multiple flows
+    name: pattern clarification
+    steps:
+      - action: action_clarify_flows
+      - action: action_increase_clarification_count
+        next:
+          - if: slots.clarification_count > 2
+            then:
+              - link: pattern_human_handoff
+          - else: clarify_options
+      - id: clarify_options
+        action: utter_clarification_options_rasa

--- a/domain/flows/authenticate_user.yml
+++ b/domain/flows/authenticate_user.yml
@@ -14,6 +14,12 @@ slots:
     type: text
     mappings:
       - type: from_llm
+  login_failed_attempts:
+    type: float
+    initial_value: 0.0
+    mappings:
+      - type: custom
+        action: action_authenticate_user
 
 responses:
   utter_authentication_failed:
@@ -24,6 +30,8 @@ responses:
     - text: Please enter your user name.
   utter_ask_user_password:
     - text: Please enter your password.
+  utter_authentication_failed_multiple_times:
+    - text: Authentication failed again. Stop authentication process.
 
 actions:
   - action_authenticate_user

--- a/domain/flows/patterns.yml
+++ b/domain/flows/patterns.yml
@@ -1,10 +1,20 @@
 version: "3.1"
 
+actions:
+  - action_increase_clarification_count
+
 slots:
   confirm_slot_correction:
     type: bool
     mappings:
       - type: from_llm
+  clarification_count:
+    type: float
+    initial_value: 0.0
+    mappings:
+      - type: custom
+        action: action_increase_clarification_count
+
 
 responses:
   utter_ask_confirm_slot_correction:


### PR DESCRIPTION
## Description
- related to issue [ENG-1207](https://rasahq.atlassian.net/browse/ENG-1207)
- link to `pattern_human_handoff` in case clarification pattern was triggered 2 times
- link to `pattern_human_handoff` in case authentication failed 3 times in `check_portfolio` flow. (Authentication fails with "John" and "1234").

## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)
