### PR TITLE
[ENG-1208] Link to `add_contact` in `pattern_clarification`

### DIFF
--- a/data/flows/patterns.yml
+++ b/data/flows/patterns.yml
@@ -52,3 +52,16 @@ flows:
     steps:
       - action: utter_can_do_something_else
       - action: action_reset_routing
+
+  pattern_clarification:
+    description: Conversation repair flow for handling ambiguous requests that could match multiple flows
+    name: pattern clarification
+    steps:
+      - action: action_clarify_flows
+        next:
+          - if: context.names contains "add a contact"
+            then:
+              - link: add_contact
+          - else: clarify_options
+      - id: clarify_options
+        action: utter_clarification_options_rasa


### PR DESCRIPTION
## Description
- related to [ENG-1208](https://rasahq.atlassian.net/browse/ENG-1208)
- Link to `add_contact` if the clarification options in `pattern_clarification` contain `add a contact`

Currently only working with the changes in https://github.com/RasaHQ/rasa-private/pull/969.

## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)
