### PR TITLE
Replace hardcoded currency strings with a regex parsing [ENG-1303]

### DIFF
--- a/actions/execute_transfer.py
+++ b/actions/execute_transfer.py
@@ -1,9 +1,13 @@
+import re
 from typing import Any, Dict
 from datetime import datetime
 from rasa_sdk import Action, Tracker
 from rasa_sdk.events import SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from actions.db import get_account, write_account, add_transaction, Transaction
+
+
+AMOUNT_OF_MONEY_REGEX = re.compile(r"\d*[.,]*\d+")
 
 
 class ExecuteTransfer(Action):
@@ -25,7 +29,7 @@ class ExecuteTransfer(Action):
         if recipient == "Jack":
             return [SlotSet("transfer_money_transfer_successful", False)]
 
-        amount_of_money_value = float(amount_of_money.replace("$", "").replace("USD", "").strip())
+        amount_of_money_value = float(re.findall(AMOUNT_OF_MONEY_REGEX, amount_of_money)[0])
         account.funds -= amount_of_money_value
         new_transaction = \
             Transaction(datetime=datetime.now().isoformat(), recipient=recipient,


### PR DESCRIPTION
Replace hardcoded currency strings with a regex parsing [ENG-1303]

This will fix a ValueError when we get a string like "50 dollars"

## Description

## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)


[ENG-1303]: https://rasahq.atlassian.net/browse/ENG-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ