### PR TITLE
ENG-1293: Update rasa-calm-demo to version 3.10.1

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -100,7 +100,7 @@ jobs:
           path: models/${{steps.upload_model.outputs.model}}.tar.gz
 
   run_e2e_tests:
-    name: Run e2e Tests
+    name: Run e2e tests
     runs-on: ubuntu-22.04
     needs: [train-model]
 
@@ -206,3 +206,112 @@ jobs:
     - name: Stop Duckling server
       run: |
           make stop-duckling
+
+  run_e2e_tests_with_assertions:
+    name: Run e2e tests with assertions
+    runs-on: ubuntu-22.04
+    needs: [train-model]
+
+    steps:
+    - name: Checkout git repository 🕝
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+    - name: Setup Python
+      uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
+      with:
+        python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+
+    - name: Install poetry 🦄
+      uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844
+      with:
+        poetry-version: ${{ env.POETRY_VERSION }}
+
+    - name: Load Poetry Cached Libraries ⬇
+      id: cache-poetry
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      with:
+        path: .venv
+        key: ${{ runner.os }}-poetry-${{ env.POETRY_VERSION }}-${{ env.DEFAULT_PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: ${{ runner.os }}-poetry-${{ env.DEFAULT_PYTHON_VERSION }}
+
+    - name: Create virtual environment
+      if: steps.cache-poetry.outputs.cache-hit != 'true'
+      run: python -m venv create .venv
+
+    - name: Set up virtual environment
+      run: poetry config virtualenvs.in-project true
+
+      # Authenticate with gcloud for release registry (where Rasa is published)
+    - id: "auth-release"
+      name: Authenticate with gcloud for release registry 🎫
+      uses: "google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d"
+      with:
+        token_format: 'access_token'
+        credentials_json: "${{ secrets.RASA_RELEASES_READ }}"
+
+    - name: Configure OAuth token for poetry
+      run: |
+        poetry config http-basic.rasa-plus oauth2accesstoken $(gcloud auth print-access-token)
+
+    - name: Install Dependencies 📦
+      run: |
+        make install
+
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      with:
+        name: trained-model
+        path: models/
+
+    - name: Init LLM Cache
+      id: cache-llm
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      with:
+        path: .rasa
+        key: rasa-llm-cache
+
+    - name: Run action server
+      env:
+        OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
+        RASA_PRO_LICENSE: ${{secrets.RASA_PRO_LICENSE}}
+        RASA_DUCKLING_HTTP_URL: ${{secrets.DUCKLING_URL}}
+        RASA_PRO_BETA_INTENTLESS: true
+      run: |
+        make actions &
+
+    - name: Run duckling server
+      run: |
+        make run-duckling
+
+    - name: Run e2e passing tests with assertions
+      env:
+        OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
+        RASA_PRO_LICENSE: ${{secrets.RASA_PRO_LICENSE}}
+        RASA_DUCKLING_HTTP_URL: ${{secrets.DUCKLING_URL}}
+        RASA_PRO_BETA_E2E_ASSERTIONS: true
+      run: |
+        make test-passing-assertions
+
+    - name: Run e2e flaky tests with assertions
+      if: always()
+      env:
+        OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
+        RASA_PRO_LICENSE: ${{secrets.RASA_PRO_LICENSE}}
+        RASA_DUCKLING_HTTP_URL: ${{secrets.DUCKLING_URL}}
+        RASA_PRO_BETA_E2E_ASSERTIONS: true
+      run: |
+        make test-flaky-assertions || true
+
+    - name: Run e2e failing tests with assertions
+      if: always()
+      env:
+        OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
+        RASA_PRO_LICENSE: ${{secrets.RASA_PRO_LICENSE}}
+        RASA_DUCKLING_HTTP_URL: ${{secrets.DUCKLING_URL}}
+        RASA_PRO_BETA_E2E_ASSERTIONS: true
+      run: |
+        make test-failing-assertions | grep '0 passed'
+
+    - name: Stop Duckling server
+      run: |
+          make stop-duckling
+

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -315,3 +315,83 @@ jobs:
       run: |
           make stop-duckling
 
+  run_e2e_tests_with_stub_custom_actions:
+    name: Run e2e tests with stub custom actions
+    runs-on: ubuntu-22.04
+    needs: [train-model]
+
+    steps:
+    - name: Checkout git repository 🕝
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+    - name: Setup Python
+      uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
+      with:
+        python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+
+    - name: Install poetry 🦄
+      uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844
+      with:
+        poetry-version: ${{ env.POETRY_VERSION }}
+
+    - name: Load Poetry Cached Libraries ⬇
+      id: cache-poetry
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      with:
+        path: .venv
+        key: ${{ runner.os }}-poetry-${{ env.POETRY_VERSION }}-${{ env.DEFAULT_PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: ${{ runner.os }}-poetry-${{ env.DEFAULT_PYTHON_VERSION }}
+
+    - name: Create virtual environment
+      if: steps.cache-poetry.outputs.cache-hit != 'true'
+      run: python -m venv create .venv
+
+    - name: Set up virtual environment
+      run: poetry config virtualenvs.in-project true
+
+      # Authenticate with gcloud for release registry (where Rasa is published)
+    - id: "auth-release"
+      name: Authenticate with gcloud for release registry 🎫
+      uses: "google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d"
+      with:
+        token_format: 'access_token'
+        credentials_json: "${{ secrets.RASA_RELEASES_READ }}"
+
+    - name: Configure OAuth token for poetry
+      run: |
+        poetry config http-basic.rasa-plus oauth2accesstoken $(gcloud auth print-access-token)
+
+    - name: Install Dependencies 📦
+      run: |
+        make install
+
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      with:
+        name: trained-model
+        path: models/
+
+    - name: Init LLM Cache
+      id: cache-llm
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      with:
+        path: .rasa
+        key: rasa-llm-cache
+
+    - name: Run duckling server
+      run: |
+        make run-duckling
+
+    - name: Run e2e passing tests with stub custom actions
+      env:
+        OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
+        RASA_PRO_LICENSE: ${{secrets.RASA_PRO_LICENSE}}
+        RASA_DUCKLING_HTTP_URL: ${{secrets.DUCKLING_URL}}
+        RASA_PRO_BETA_E2E_ASSERTIONS: true
+        RASA_PRO_BETA_STUB_CUSTOM_ACTION: true
+      run: |
+        make test-passing-stub-custom-actions
+
+    - name: Stop Duckling server
+      run: |
+        make stop-duckling
+

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -174,6 +174,10 @@ jobs:
       run: |
         make run-duckling
 
+    - name: Make test results directory
+      run: |
+        mkdir tests
+
     - name: Run e2e passing tests
       env:
         OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
@@ -181,7 +185,14 @@ jobs:
         RASA_DUCKLING_HTTP_URL: ${{secrets.DUCKLING_URL}}
         RASA_PRO_BETA_INTENTLESS: true
       run: |
-        make test-passing
+        make test-passing 
+
+    - name: Save test-passing results
+      if: failure()
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: test-passing-results
+        path: tests/
 
     - name: Run e2e flaky tests
       if: always()
@@ -194,6 +205,7 @@ jobs:
         make test-flaky || true
 
     - name: Run e2e failing tests
+      id: run-e2e-failing-tests 
       if: always()
       env:
         OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
@@ -202,6 +214,13 @@ jobs:
         RASA_PRO_BETA_INTENTLESS: true
       run: |
         make test-failing | grep '0 passed'
+
+    - name: Save test-failing results
+      if: failure() && steps.run-e2e-failing-tests.outcome == 'failure'
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: test-failing-results
+        path: tests/*passed.yml
 
     - name: Stop Duckling server
       run: |
@@ -282,6 +301,10 @@ jobs:
       run: |
         make run-duckling
 
+    - name: Make test results directory
+      run: |
+        mkdir tests
+
     - name: Run e2e passing tests with assertions
       env:
         OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
@@ -289,7 +312,14 @@ jobs:
         RASA_DUCKLING_HTTP_URL: ${{secrets.DUCKLING_URL}}
         RASA_PRO_BETA_E2E_ASSERTIONS: true
       run: |
-        make test-passing-assertions
+        make test-passing-assertions 
+
+    - name: Save test-passing-assertions results
+      if: failure()
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: test-passing-assertions-results
+        path: tests/
 
     - name: Run e2e flaky tests with assertions
       if: always()
@@ -302,6 +332,7 @@ jobs:
         make test-flaky-assertions || true
 
     - name: Run e2e failing tests with assertions
+      id: run-e2e-failing-tests-with-assertions
       if: always()
       env:
         OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
@@ -310,6 +341,13 @@ jobs:
         RASA_PRO_BETA_E2E_ASSERTIONS: true
       run: |
         make test-failing-assertions | grep '0 passed'
+
+    - name: Save test-failing-assertions results
+      if: failure() && steps.run-e2e-failing-tests-with-assertions.outcome == 'failure'
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: test-failing-assertions-results
+        path: tests/*passed.yml
 
     - name: Stop Duckling server
       run: |
@@ -381,6 +419,10 @@ jobs:
       run: |
         make run-duckling
 
+    - name: Make test results directory
+      run: |
+        mkdir tests
+
     - name: Run e2e passing tests with stub custom actions
       env:
         OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
@@ -389,7 +431,14 @@ jobs:
         RASA_PRO_BETA_E2E_ASSERTIONS: true
         RASA_PRO_BETA_STUB_CUSTOM_ACTION: true
       run: |
-        make test-passing-stub-custom-actions
+        make test-passing-stub-custom-actions 
+
+    - name: Save test-stub-custom-actions-passing results
+      if: failure()
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: test-stub-custom-actions-passing-results
+        path: tests/
 
     - name: Stop Duckling server
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ models/
 prompts/
 tests/
 qdrant_storage/
+
+# mlflow
+mlruns/

--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,6 @@ test-flaky-assertions: .EXPORT_ALL_VARIABLES
 
 test-failing-assertions: .EXPORT_ALL_VARIABLES
 	poetry run rasa test e2e e2e_tests_with_assertions/failing
+
+make test-passing-stub-custom-actions: .EXPORT_ALL_VARIABLES
+	poetry run rasa test e2e e2e_tests_with_stub_custom_actions/passing

--- a/Makefile
+++ b/Makefile
@@ -75,16 +75,16 @@ actions:
 	poetry run rasa run actions
 
 test-passing: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests/passing
+	poetry run rasa test e2e e2e_tests/passing --e2e-results
 
 test-flaky: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests/flaky
+	poetry run rasa test e2e e2e_tests/flaky --e2e-results
 
 test-failing: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests/failing
+	poetry run rasa test e2e e2e_tests/failing --e2e-results
 
 test-multistep: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests/multistep
+	poetry run rasa test e2e e2e_tests/multistep --e2e-results
 
 test-one: .EXPORT_ALL_VARIABLES
 	poetry run rasa test e2e $(target) --debug
@@ -93,13 +93,13 @@ stop-duckling:
 	docker stop duckling_container
 
 test-passing-assertions: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests_with_assertions/passing
+	poetry run rasa test e2e e2e_tests_with_assertions/passing --e2e-results
 
 test-flaky-assertions: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests_with_assertions/flaky
+	poetry run rasa test e2e e2e_tests_with_assertions/flaky --e2e-results
 
 test-failing-assertions: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests_with_assertions/failing
+	poetry run rasa test e2e e2e_tests_with_assertions/failing --e2e-results
 
 make test-passing-stub-custom-actions: .EXPORT_ALL_VARIABLES
-	poetry run rasa test e2e e2e_tests_with_stub_custom_actions/passing
+	poetry run rasa test e2e e2e_tests_with_stub_custom_actions/passing --e2e-results

--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,12 @@ test-one: .EXPORT_ALL_VARIABLES
 
 stop-duckling:
 	docker stop duckling_container
+
+test-passing-assertions: .EXPORT_ALL_VARIABLES
+	poetry run rasa test e2e e2e_tests_with_assertions/passing
+
+test-flaky-assertions: .EXPORT_ALL_VARIABLES
+	poetry run rasa test e2e e2e_tests_with_assertions/flaky
+
+test-failing-assertions: .EXPORT_ALL_VARIABLES
+	poetry run rasa test e2e e2e_tests_with_assertions/failing

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This demo showcases a chatbot built with Rasa's LLM-native approach: [CALM](http
 > CALM's current stage of development.
 
 > [!NOTE]
-> This demo bot is currently compatible with `3.9.3`.
+> This demo bot is currently compatible with `3.10.1`.
 
 ## Terms of Use
 
@@ -244,8 +244,8 @@ and run end-to-end tests.
 > please refer our documentation [here](https://rasa.com/docs/rasa-pro/installation/python/installation).
 
 > [!NOTE]
-> If you want to check out the state of the demo bot compatible with Rasa 3.8.8, please check out the branch
-> [3.8.x](https://github.com/RasaHQ/rasa-calm-demo/tree/3.8.x).
+> If you want to check out the state of the demo bot compatible with Rasa 3.9, please check out the branch
+> [3.9.x](https://github.com/RasaHQ/rasa-calm-demo/tree/3.9.x).
 
 Prerequisites:
 - rasa pro license
@@ -370,7 +370,7 @@ rasa inspect --debug
 rasa shell --debug
 ```
 
-### Running e2e test
+### Running e2e tests
 
 The demo bot comes with a set of e2e tests, categorized into two primary groups: 
 **failing**, and **passing**. These tests are organized not per individual flow but 
@@ -445,3 +445,38 @@ or
 ```commandline
 run rasa test e2e e2e_tests/multistep
 ```
+
+#### E2E tests with assertions
+To enable the feature, please set the environment variable `RASA_PRO_BETA_E2E_ASSERTIONS` to true in your testing environment.
+
+`export RASA_PRO_BETA_E2E_ASSERTIONS=true`
+
+To run **all the tests**:
+
+```commandline
+rasa test e2e e2e_tests_with_assertions
+```
+
+------
+
+To run **passing/failing/flaky** tests:
+```commandline
+rasa test e2e e2e_tests_with_assertions/passing
+```
+```commandline
+rasa test e2e e2e_tests_with_assertions/failing
+```
+```commandline
+rasa test e2e e2e_tests_with_assertions/flaky
+```
+
+------
+
+To run a **single test** , provide the path to a 
+target test:
+
+```commandline
+rasa test e2e e2e_tests_with_assertions/tests/path/to/a/target/test.yml
+```
+
+------

--- a/actions/action_increase_clarification_count.py
+++ b/actions/action_increase_clarification_count.py
@@ -1,0 +1,23 @@
+from rasa_sdk.events import SlotSet
+from rasa_sdk import Action, Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+
+class ActionIncreaseClarificationCount(Action):
+    """Action which clarifies which flow to start."""
+
+    def name(self) -> str:
+        """Return the flow name."""
+        return "action_increase_clarification_count"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: dict
+    ) -> list:
+        attempts = tracker.get_slot("clarification_count")
+        if not attempts:
+            attempts = 0
+
+        return [SlotSet("clarification_count", attempts + 1)]

--- a/actions/ask_for_slot_action.py
+++ b/actions/ask_for_slot_action.py
@@ -47,7 +47,7 @@ class AskForRestaurantFormRestaurantName(Action):
 
         if len(restaurant_names) > 0:
             dispatcher.utter_message(
-                text="Do you know which restaurant you would like me to reverse a table at?",
+                text="Do you know which restaurant you would like me to reserve a table at?",
                 buttons=[
                     {"title": r, "payload": f'/inform{{"restaurant_name":"{r}"}}'}
                     for r in restaurant_names

--- a/actions/authenticate_user.py
+++ b/actions/authenticate_user.py
@@ -13,13 +13,16 @@ class ActionAuthenticateUser(Action):
         # Retrieve the user credentials from slots
         user_name = tracker.get_slot("user_name")
         user_password = tracker.get_slot("user_password")
+        attempts = tracker.get_slot("login_failed_attempts")
+        if not attempts:
+            attempts = 0
 
         # Dummy authentication.
         # Placeholder for user authentication, in real scenarios the username and
         # password should be checked against a database.
-        authenticated = True
+        authenticated = not (user_name == "John" and user_password == "1234")
 
         if authenticated:
             return [SlotSet("is_user_logged_in", True)]
         else:
-            return [SlotSet("is_user_logged_in", False)]
+            return [SlotSet("is_user_logged_in", False), SlotSet("login_failed_attempts", attempts + 1)]

--- a/actions/execute_transfer.py
+++ b/actions/execute_transfer.py
@@ -1,9 +1,13 @@
+import re
 from typing import Any, Dict
 from datetime import datetime
 from rasa_sdk import Action, Tracker
 from rasa_sdk.events import SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from actions.db import get_account, write_account, add_transaction, Transaction
+
+
+AMOUNT_OF_MONEY_REGEX = re.compile(r"\d*[.,]*\d+")
 
 
 class ExecuteTransfer(Action):
@@ -25,7 +29,7 @@ class ExecuteTransfer(Action):
         if recipient == "Jack":
             return [SlotSet("transfer_money_transfer_successful", False)]
 
-        amount_of_money_value = float(amount_of_money.replace("$", "").replace("USD", "").strip())
+        amount_of_money_value = float(re.findall(AMOUNT_OF_MONEY_REGEX, amount_of_money)[0])
         account.funds -= amount_of_money_value
         new_transaction = \
             Transaction(datetime=datetime.now().isoformat(), recipient=recipient,

--- a/actions/setup_recurrent_payment.py
+++ b/actions/setup_recurrent_payment.py
@@ -20,7 +20,8 @@ def parse_datetime(text: str) -> Optional[datetime]:
     if isinstance(parsed_value, dict):
         parsed_value = parsed_value["from"]
 
-    return datetime.fromisoformat(parsed_value)
+    result = datetime.fromisoformat(parsed_value)
+    return result.replace(tzinfo=None)
 
 
 class ValidatePaymentStartDate(Action):
@@ -43,7 +44,7 @@ class ValidatePaymentStartDate(Action):
             dispatcher.utter_message(response="utter_invalid_date")
             return [SlotSet("recurrent_payment_start_date", None)]
 
-        return [SlotSet("recurrent_payment_start_date", start_date.isoformat())]
+        return [SlotSet("recurrent_payment_start_date", start_date.strftime("%Y-%m-%d"))]
 
 
 class ValidatePaymentEndDate(Action):
@@ -66,11 +67,11 @@ class ValidatePaymentEndDate(Action):
             return [SlotSet("recurrent_payment_end_date", None)]
 
         start_date = tracker.get_slot("recurrent_payment_start_date")
-        if start_date is not None and end_date < datetime.fromisoformat(start_date):
+        if start_date is not None and end_date < datetime.strptime(start_date, "%Y-%m-%d"):
             dispatcher.utter_message(response="utter_invalid_date")
             return [SlotSet("recurrent_payment_end_date", None)]
 
-        return [SlotSet("recurrent_payment_end_date", end_date.isoformat())]
+        return [SlotSet("recurrent_payment_end_date", end_date.strftime("%Y-%m-%d"))]
 
 
 class ExecutePayment(Action):

--- a/config/config.yml
+++ b/config/config.yml
@@ -28,7 +28,7 @@ pipeline:
 - name: NLUCommandAdapter
 - name: SingleStepLLMCommandGenerator
   llm:
-    model_name: gpt-4
+    model: gpt-4
     request_timeout: 7
     temperature: 0.0
     top_p: 0.0

--- a/config/config.yml
+++ b/config/config.yml
@@ -29,7 +29,7 @@ pipeline:
 - name: SingleStepLLMCommandGenerator
   llm:
     model: gpt-4
-    request_timeout: 7
+    timeout: 7
     temperature: 0.0
     top_p: 0.0
 

--- a/config/multistep-config.yml
+++ b/config/multistep-config.yml
@@ -28,8 +28,8 @@ pipeline:
 - name: NLUCommandAdapter
 - name: MultiStepLLMCommandGenerator
   llm:
-    model_name: gpt-3.5-turbo-0125
-    request_timeout: 7
+    model: gpt-3.5-turbo-0125
+    timeout: 7
     temperature: 0.0
     top_p: 0.0
 

--- a/config/qdrant-config.yml
+++ b/config/qdrant-config.yml
@@ -28,8 +28,8 @@ pipeline:
 - name: NLUCommandAdapter
 - name: SingleStepLLMCommandGenerator
   llm:
-    model_name: gpt-4
-    request_timeout: 7
+    model: gpt-4
+    timeout: 7
     temperature: 0.0
     top_p: 0.0
 
@@ -44,8 +44,8 @@ policies:
   vector_store:
     type: "addons.qdrant.Qdrant_Store"
   embeddings:
-    type: "huggingface"
-    model_name: "BAAI/bge-small-en-v1.5"
+    provider: "huggingface"
+    model: "BAAI/bge-small-en-v1.5"
     model_kwargs:
       device: 'cpu'
     encode_kwargs:

--- a/data/flows/authenticate_user.yml
+++ b/data/flows/authenticate_user.yml
@@ -15,9 +15,16 @@ flows:
         description: "The password of the user."
       - action: action_authenticate_user
         next:
+        - if: slots.login_failed_attempts >= 3
+          then:
+            - action: utter_authentication_failed_multiple_times
+              next: END
         - if: not slots.is_user_logged_in
           then:
             - action: utter_authentication_failed
+            - set_slots:
+                - user_name: null
+                - user_password: null
               next: ask_user_credentials
         - else:
             - action: utter_authentication_successful

--- a/data/flows/check_portfolio.yml
+++ b/data/flows/check_portfolio.yml
@@ -3,7 +3,13 @@ flows:
     description: "Check the user's investment portfolio, including stocks, bonds, and mutual funds."
     steps:
       - call: authenticate_user
-      - collect: portfolio_type
+        next:
+          - if: slots.login_failed_attempts >= 3
+            then:
+              - link: pattern_human_handoff
+          - else: collect_portfolio_type
+      - id: collect_portfolio_type
+        collect: portfolio_type
         description: "The type of portfolio, for example: stocks, bonds or mutual_funds."
       - action: action_check_portfolio_exists
         next:

--- a/data/flows/patterns.yml
+++ b/data/flows/patterns.yml
@@ -52,3 +52,22 @@ flows:
     steps:
       - action: utter_can_do_something_else
       - action: action_reset_routing
+
+  pattern_clarification:
+    description: Conversation repair flow for handling ambiguous requests that could match multiple flows
+    name: pattern clarification
+    steps:
+      - action: action_clarify_flows
+        next:
+          - if: context.names contains "add a contact"
+            then:
+              - link: add_contact
+          - else: 
+            - action: action_increase_clarification_count
+              next:
+                - if: slots.clarification_count > 2
+                  then:
+                    - link: pattern_human_handoff
+                - else: clarify_options
+      - id: clarify_options
+        action: utter_clarification_options_rasa

--- a/domain/flows/authenticate_user.yml
+++ b/domain/flows/authenticate_user.yml
@@ -14,6 +14,12 @@ slots:
     type: text
     mappings:
       - type: from_llm
+  login_failed_attempts:
+    type: float
+    initial_value: 0.0
+    mappings:
+      - type: custom
+        action: action_authenticate_user
 
 responses:
   utter_authentication_failed:
@@ -24,6 +30,8 @@ responses:
     - text: Please enter your user name.
   utter_ask_user_password:
     - text: Please enter your password.
+  utter_authentication_failed_multiple_times:
+    - text: Authentication failed again. Stop authentication process.
 
 actions:
   - action_authenticate_user

--- a/domain/flows/check_portfolio.yml
+++ b/domain/flows/check_portfolio.yml
@@ -31,7 +31,7 @@ responses:
           title: stocks
         - payload: bonds
           title: bonds
-        - payload: mutual_funds
+        - payload: /SetSlots(portfolio_type=mutual_funds)
           title: mutual funds
   utter_portfolio_options_found:
     - text: "Your {portfolio_type} portfolio: {portfolio_options}"

--- a/domain/flows/patterns.yml
+++ b/domain/flows/patterns.yml
@@ -1,10 +1,20 @@
 version: "3.1"
 
+actions:
+  - action_increase_clarification_count
+
 slots:
   confirm_slot_correction:
     type: bool
     mappings:
       - type: from_llm
+  clarification_count:
+    type: float
+    initial_value: 0.0
+    mappings:
+      - type: custom
+        action: action_increase_clarification_count
+
 
 responses:
   utter_ask_confirm_slot_correction:
@@ -21,3 +31,7 @@ responses:
     - text: Ok, I did not correct the previous input.
       metadata:
         rephrase: True
+  utter_human_handoff_not_available:
+    - text: I understand you want to be connected to a human agent, but that's something I cannot help you with at the moment. Is there something else I can help you with?
+      metadata:
+        rephrase: False

--- a/e2e_tests/passing/happy_path/user_checks_portfolio.yml
+++ b/e2e_tests/passing/happy_path/user_checks_portfolio.yml
@@ -8,7 +8,7 @@ test_cases:
       - user: "1234"
       - utter: utter_authentication_successful
       - utter: utter_ask_portfolio_type
-      - user: mutual funds
+      - user: /SetSlots(portfolio_type=mutual_funds)
       - slot_was_set:
         - portfolio_type: mutual_funds
         - portfolio_exists: True

--- a/e2e_tests_with_assertions/failing/potential_bugs/user_tries_to_use_abstract_values.yml
+++ b/e2e_tests_with_assertions/failing/potential_bugs/user_tries_to_use_abstract_values.yml
@@ -1,0 +1,32 @@
+test_cases:
+  - test_case: user tries to use abstract values
+    steps:
+      - user: send money
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      # the llm is extracting "good friend" as the recipient
+      - user: to a good friend
+        assertions:
+          - slot_was_not_set:
+              - name: transfer_money_recipient
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: okay, to Mary
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Mary
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: "50"
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "50"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/failing/skip_question/user_tries_to_skip_a_question_and_then_cancels_the_flow_hard.yml
+++ b/e2e_tests_with_assertions/failing/skip_question/user_tries_to_skip_a_question_and_then_cancels_the_flow_hard.yml
@@ -1,0 +1,23 @@
+test_cases:
+  - test_case: user tries to skip a question and then cancels the flow (hard)
+    steps:
+      - user: send money to John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: i don't want to answer this
+        assertions:
+          # cancel flow instead of skip question is predicted
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: i don't want to continue
+        assertions:
+          - bot_uttered:
+              utter_name: utter_flow_cancelled_rasa
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/failing/skip_question/user_tries_to_skip_a_question_multiple_times_hard.yml
+++ b/e2e_tests_with_assertions/failing/skip_question/user_tries_to_skip_a_question_multiple_times_hard.yml
@@ -1,0 +1,34 @@
+test_cases:
+  - test_case: user tries to skip a question multiple times (hard)
+    steps:
+      - user: send money to John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: i don't want to answer this for now
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: i don't want to answer this
+      # cancel flow instead of skip question is predicted
+        assertions:
+        - bot_uttered:
+            utter_name: utter_skip_question_answer
+        - bot_uttered:
+            utter_name: utter_ask_transfer_money_amount_of_money
+      - user: okay 50
+        assertions:
+          - slot_was_set:
+              - name: utter_ask_transfer_money_amount_of_money
+                value: "50"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/failing/skip_question/user_tries_to_skip_a_question_once_hard.yml
+++ b/e2e_tests_with_assertions/failing/skip_question/user_tries_to_skip_a_question_once_hard.yml
@@ -1,0 +1,28 @@
+test_cases:
+  - test_case: user tries to skip a question once (hard)
+    steps:
+      - user: send money to John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: i don't want to answer this
+        assertions:
+          # cancel flow instead of skip question is predicted
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: okay 50
+        assertions:
+          - slot_was_set:
+              - name: utter_ask_transfer_money_amount_of_money
+                value: "50"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/flaky/disambiguation/user_sends_short_noun_only_message.yml
+++ b/e2e_tests_with_assertions/flaky/disambiguation/user_sends_short_noun_only_message.yml
@@ -1,0 +1,19 @@
+# instead of clarify a start flow command for "list_contact" is predicted
+
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user sends short noun only message
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: contact
+        assertions:
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: add
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_handle

--- a/e2e_tests_with_assertions/flaky/happy_path/user_sets_up_recurrent_payment.yml
+++ b/e2e_tests_with_assertions/flaky/happy_path/user_sets_up_recurrent_payment.yml
@@ -1,0 +1,16 @@
+# recurrent_payment_type is not mapped to standing order
+
+test_cases:
+  - test_case: user wants to set up a new recurrent payment, but specifies the type incompletely, example 3
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: stand order
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_type
+                value: standing order
+          - bot_uttered:
+              utter_name: utter_ask_recipient

--- a/e2e_tests_with_assertions/flaky/happy_path/user_wants_to_register_to_vote.yml
+++ b/e2e_tests_with_assertions/flaky/happy_path/user_wants_to_register_to_vote.yml
@@ -1,0 +1,15 @@
+fixtures:
+  - non_california_resident:
+      - based_in_california: False
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: Register to vote for non-California resident (should not trigger)
+    fixtures:
+      - non_california_resident
+    steps:
+      - user: I want to register to vote
+        # ChitChat is predicted instead of no command being predicted
+        assertions:
+          - bot_uttered:
+              utter_name: utter_cannot_answer

--- a/e2e_tests_with_assertions/flaky/invalid_path/user_tries_to_set_up_recurrent_payment_with_invalid_values.yml
+++ b/e2e_tests_with_assertions/flaky/invalid_path/user_tries_to_set_up_recurrent_payment_with_invalid_values.yml
@@ -1,0 +1,53 @@
+test_cases:
+  - test_case: user wants to set up a new one off payment and starts a different flow
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: international transfer
+      # leads to Clarify('direct debit', 'standing order') which is dropped, so CannotHandle command is predicted and
+      # results in utter_ask_rephrase
+        assertions:
+          - bot_uttered:
+              utter_name: utter_categorical_slot_rejection
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: none of these, actually just need a one off payment
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+
+  - test_case: user wants to set up an invalid payment type and the assistant re-asks in a loop until a valid value is given
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: international transfer
+      # leads to Clarify('direct debit', 'standing order') which is dropped, so CannotHandle command is predicted and
+      # results in utter_ask_rephrase
+        assertions:
+          - bot_uttered:
+              utter_name: utter_categorical_slot_rejection
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: international transfer
+        assertions:
+          - bot_uttered:
+              utter_name: utter_categorical_slot_rejection
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: international transfer
+        assertions:
+          - bot_uttered:
+              utter_name: utter_categorical_slot_rejection
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: direct debit
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_type
+                value: "direct debit"
+          - bot_uttered:
+              utter_name: utter_ask_recipient

--- a/e2e_tests_with_assertions/flaky/negations/users_says_they_dont_want_one_option.yml
+++ b/e2e_tests_with_assertions/flaky/negations/users_says_they_dont_want_one_option.yml
@@ -1,0 +1,17 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user says they don't want one option
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: cash
+        assertions:
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: not transfer
+        assertions:
+          - bot_uttered:
+              utter_name: utter_current_balance

--- a/e2e_tests_with_assertions/flaky/negations/users_says_they_dont_want_one_option_among_three.yml
+++ b/e2e_tests_with_assertions/flaky/negations/users_says_they_dont_want_one_option_among_three.yml
@@ -1,0 +1,21 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user says they don't want one option among three
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: contact
+        assertions:
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: not remove
+        assertions:
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: the latter
+        assertions:
+          - bot_uttered:
+              utter_name: utter_list_contacts

--- a/e2e_tests_with_assertions/flaky/negations/users_says_they_dont_want_two_options.yml
+++ b/e2e_tests_with_assertions/flaky/negations/users_says_they_dont_want_two_options.yml
@@ -1,0 +1,17 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user says they don't want two options
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: contact
+        assertions:
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: not add or remove
+        assertions:
+          - bot_uttered:
+              utter_name: utter_list_contacts

--- a/e2e_tests_with_assertions/flaky/potential_bugs/user_asks_to_start_10_transfers.yml
+++ b/e2e_tests_with_assertions/flaky/potential_bugs/user_asks_to_start_10_transfers.yml
@@ -1,0 +1,31 @@
+# The first utterance ("10 transfers") already sets the amount of money to 10
+
+test_cases:
+  - test_case: user asks to start 10 transfers
+    steps:
+      - user: Please start ten transfers to Jim
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Jim
+          - slot_was_not_set:
+              - name: utter_ask_transfer_money_amount_of_money
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: "10"
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "10"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+          - bot_uttered:
+              utter_name: utter_can_do_something_else
+      - user: show my transactions please
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transactions

--- a/e2e_tests_with_assertions/flaky/skip_questions/user_tries_to_skip_a_question_multiple_times_easy.yml
+++ b/e2e_tests_with_assertions/flaky/skip_questions/user_tries_to_skip_a_question_multiple_times_easy.yml
@@ -1,0 +1,72 @@
+# cancel flow is predicted instead of skip question
+
+test_cases:
+  - test_case: user tries to skip a question multiple times (easy)
+    steps:
+      - user: send money to John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: skip this question
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: skip this step
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: go to next question
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: go to next step
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: skip this
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: next one
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: skip
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: next
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: okay 50
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "50"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+

--- a/e2e_tests_with_assertions/passing/cancellations/cancellation_respects_scope.yml
+++ b/e2e_tests_with_assertions/passing/cancellations/cancellation_respects_scope.yml
@@ -1,0 +1,26 @@
+test_cases:
+  - test_case: cancellation_respects_scope
+    steps:
+      - user: send money to John
+        assertions:
+            - slot_was_set:
+                - name: route_session_to_calm
+                  value: True
+                - name: transfer_money_recipient
+                  value: John
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: cancel
+        assertions:
+          - flow_started: pattern_cancel_flow
+          - bot_uttered:
+              utter_name: utter_flow_cancelled_rasa
+          - slot_was_set:
+                - name: transfer_money_recipient
+                  value: null
+          - bot_uttered:
+              utter_name: utter_can_do_something_else
+      - user: send money
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient

--- a/e2e_tests_with_assertions/passing/cancellations/immediate_cancellation_and_start_of_new_flow.yml
+++ b/e2e_tests_with_assertions/passing/cancellations/immediate_cancellation_and_start_of_new_flow.yml
@@ -1,0 +1,26 @@
+test_cases:
+  - test_case: immediate_cancellation_and_start_of_new_flow
+    steps:
+      - user: I want to send money
+        assertions:
+        - slot_was_set:
+            - name: route_session_to_calm
+              value: True
+        - bot_uttered:
+            utter_name: utter_ask_transfer_money_recipient
+      - user: ah, one moment stop that. I want to see my transfers first
+        assertions:
+        - flow_started: pattern_cancel_flow
+        - bot_uttered:
+            utter_name: utter_flow_cancelled_rasa
+        - bot_uttered:
+            utter_name: utter_transactions
+        - bot_uttered:
+            utter_name: utter_can_do_something_else
+      - user: okay, send money to Jill
+        assertions:
+        - slot_was_set:
+            - name: transfer_money_recipient
+              value: Jill
+        - bot_uttered:
+            utter_name: utter_ask_transfer_money_amount_of_money

--- a/e2e_tests_with_assertions/passing/cancellations/user_cancels_default_pattern_override_no_confirmation.yml
+++ b/e2e_tests_with_assertions/passing/cancellations/user_cancels_default_pattern_override_no_confirmation.yml
@@ -1,0 +1,20 @@
+test_cases:
+  - test_case: user_cancels_default_pattern_override_no_confirmation
+    steps:
+      - user: I would like to add a new contact
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: true
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_handle
+      - user: "@max"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_name
+      - user: Actually, cancel that please.
+        assertions:
+          - flow_cancelled:
+              flow_id: add_contact
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/cancellations/user_cancels_during_a_correction.yml
+++ b/e2e_tests_with_assertions/passing/cancellations/user_cancels_during_a_correction.yml
@@ -1,0 +1,23 @@
+test_cases:
+  - test_case: user_cancels_during_a_correction
+    steps:
+      - user: I want to send money to Joe
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+              - name: transfer_money_recipient
+                value: Joe
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: oh sorry I meant John
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: never mind, cancel the transfer
+        assertions:
+          - flow_started: pattern_cancel_flow
+          - bot_uttered:
+              utter_name: utter_flow_cancelled_rasa
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/cancellations/user_changes_mind_based_on_new_info.yml
+++ b/e2e_tests_with_assertions/passing/cancellations/user_changes_mind_based_on_new_info.yml
@@ -1,0 +1,25 @@
+test_cases:
+  - test_case: user_changes_mind_based_on_new_info
+    steps:
+      - user: Send some money to Joe
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+              - name: transfer_money_recipient
+                value: Joe
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: Ah one moment, show transactions.
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transactions
+          - bot_uttered:
+              utter_name: utter_flow_continue_interrupted
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: Ah never mind, I already sent the money earlier
+        assertions:
+          - flow_started: pattern_cancel_flow
+          - bot_uttered:
+              utter_name: utter_flow_cancelled_rasa

--- a/e2e_tests_with_assertions/passing/cancellations/user_changes_mind_on_a_whim.yml
+++ b/e2e_tests_with_assertions/passing/cancellations/user_changes_mind_on_a_whim.yml
@@ -1,0 +1,15 @@
+test_cases:
+  - test_case: user_changes_mind_on_a_whim
+    steps:
+      - user: I want to send money
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: stop
+        assertions:
+            - flow_started: pattern_cancel_flow
+            - bot_uttered:
+                utter_name: utter_flow_cancelled_rasa

--- a/e2e_tests_with_assertions/passing/chitchat/user_greets.yml
+++ b/e2e_tests_with_assertions/passing/chitchat/user_greets.yml
@@ -1,0 +1,7 @@
+test_cases:
+  - test_case: user greets
+    steps:
+      - user: Hi, there
+        assertions:
+          - bot_uttered:
+              utter_name: utter_greet

--- a/e2e_tests_with_assertions/passing/chitchat/user_says_goodbye.yml
+++ b/e2e_tests_with_assertions/passing/chitchat/user_says_goodbye.yml
@@ -1,0 +1,20 @@
+test_cases:
+  - test_case: user says goodbye
+    steps:
+      - user: I want to send 10 bucks to Spencer
+        assertions:
+            - slot_was_set:
+                - name: route_session_to_calm
+                  value: True
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "Yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+          - bot_uttered:
+              utter_name: utter_can_do_something_else
+      - user: Bye then
+        assertions:
+          - bot_uttered:
+              utter_name: utter_goodbye

--- a/e2e_tests_with_assertions/passing/chitchat/user_says_something_surprising.yml
+++ b/e2e_tests_with_assertions/passing/chitchat/user_says_something_surprising.yml
@@ -1,0 +1,13 @@
+test_cases:
+  - test_case: user_says_something_intriguing
+    steps:
+      - user: I just had the most wonderful startup idea.
+        assertions:
+          - bot_uttered:
+              utter_name: utter_intriguing
+          - generative_response_is_relevant:
+              utter_name: utter_intriguing
+              threshold: 0.70
+          - generative_response_is_grounded:
+              utter_name: utter_intriguing
+              threshold: 0.90

--- a/e2e_tests_with_assertions/passing/corrections/user_cancels_correction.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_cancels_correction.yml
@@ -1,0 +1,32 @@
+test_cases:
+  - test_case: user_cancels_correction
+    steps:
+      - user: send John 50
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+              - name: transfer_money_amount_of_money
+                value: "50"
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: Ah wait I think I actually owe him 60
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=false)
+        assertions:
+          - bot_uttered:
+              utter_name: utter_not_corrected_previous_input
+          - generative_response_is_grounded:
+              utter_name: utter_not_corrected_previous_input
+              threshold: 0.80
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "Yes"
+        assertions:
+          - bot_uttered:
+              text_matches: Successfully transferred 50 to John.

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_a_boolean_slot.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_a_boolean_slot.yml
@@ -1,0 +1,38 @@
+metadata:
+  - turn_1:
+      turn_idx: 1
+  - turn_2:
+      turn_idx: 2
+
+test_cases:
+  - test_case: user_corrects_a_boolean_slot
+    steps:
+      - user: I want to verify my account
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: "It's mag@pie.com"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_based_in_california
+      - user: "yes"
+        metadata: turn_1
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_sufficient_california_income
+      - user: "yes"
+        metadata: turn_2
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_confirmation
+      - user: Actually my income is not that high
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_sufficient_california_income
+      - user: "no"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ca_income_insufficient

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_a_branching_slot.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_a_branching_slot.yml
@@ -1,0 +1,48 @@
+metadata:
+  - duplicate_msg_correction_1:
+      turn_idx: 1
+  - duplicate_msg_correction_2:
+      turn_idx: 2
+test_cases:
+  - test_case: user_corrects_a_branching_slot
+    steps:
+      - user: I want to verify my account
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: It's birdie@example.com
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_based_in_california
+      - user: "yes"
+        metadata: duplicate_msg_correction_1
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_sufficient_california_income
+      - user: sorry, I need to correct the previous input
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+          - bot_uttered:
+              utter_name: utter_corrected_previous_input
+          - slot_was_set:
+              - name: based_in_california
+          - bot_uttered:
+              utter_name: utter_ask_based_in_california
+      - user: "no"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_confirmation
+      - user: "yes"
+        metadata: duplicate_msg_correction_2
+        assertions:
+          - bot_uttered:
+              utter_name: utter_verify_account_success
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_a_number_slot.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_a_number_slot.yml
@@ -1,0 +1,44 @@
+test_cases:
+  - test_case: user_corrects_a_number_slot
+    steps:
+    - user: I want to book a table
+      assertions:
+        - slot_was_set:
+            - name: route_session_to_calm
+              value: False
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_city
+    - user: /inform{"location":"amsterdam"}
+      assertions:
+        - action_executed: restaurant_form
+        - bot_uttered:
+            text_matches: "What cuisine are you looking for?"
+    - user: /inform{"cuisine":"Japanese"}
+      assertions:
+        - action_executed: restaurant_form
+        - bot_uttered:
+            text_matches: "Do you know which restaurant you would like me to reserve a table at?"
+    - user: /inform{"restaurant_name":"Yamazato Restaurant"}
+      assertions:
+        - bot_uttered:
+             utter_name: utter_ask_restaurant_form_num_people
+    - user: "4"
+      assertions:
+        - slot_was_set:
+            - name: num_people
+              value: 4
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_restaurant_time
+    - user: sorry, we are 6 people
+      assertions:
+        - slot_was_set:
+            - name: num_people
+              value: 6
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_restaurant_time
+    - user: tomorrow at 7pm
+      assertions:
+        - bot_uttered:
+            utter_name: utter_restaurant_form_submit
+        - bot_uttered:
+            utter_name: utter_restaurant_available

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_amount_of_money_in_the_next_message.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_amount_of_money_in_the_next_message.yml
@@ -1,0 +1,44 @@
+test_cases:
+  - test_case: user_corrects_amount_of_money_in_the_next_message
+    steps:
+      - user: I want to transfer money
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: 100 USD
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "100"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: Ah, scratch that, I meant 110$
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "110"
+          - bot_uttered:
+              utter_name: utter_corrected_previous_input
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+          - flow_completed:
+              flow_id: transfer_money

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_mentioning_old_value_first.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_mentioning_old_value_first.yml
@@ -1,0 +1,45 @@
+test_cases:
+  - test_case: user_corrects_mentioning_old_value_first
+    steps:
+      - user: I want to transfer money
+        assertions:
+            - slot_was_set:
+                - name: route_session_to_calm
+                  value: True
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_recipient
+      - user: John
+        assertions:
+            - slot_was_set:
+                - name: transfer_money_recipient
+                  value: John
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: "50"
+        assertions:
+            - slot_was_set:
+                - name: transfer_money_amount_of_money
+                  value: "50"
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: Ah, not 50, I meant 55
+        assertions:
+            - flow_started: pattern_correction
+            - bot_uttered:
+                utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "55"
+          - bot_uttered:
+              utter_name: utter_corrected_previous_input
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transfer_complete
+            - flow_completed:
+                flow_id: transfer_money
+      - utter: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_mentioning_old_value_last.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_mentioning_old_value_last.yml
@@ -1,0 +1,41 @@
+test_cases:
+  - test_case: user_corrects_mentioning_old_value_last
+    steps:
+      - user: I want to transfer money
+        assertions:
+            - slot_was_set:
+                - name: route_session_to_calm
+                  value: True
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_recipient
+      - user: John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: Sorry, I meant to say Jimmy, not John
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Jimmy
+          - bot_uttered:
+              utter_name: utter_corrected_previous_input
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: 50$
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+          - flow_completed:
+              flow_id: transfer_money

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_recipient_in_the_next_message.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_recipient_in_the_next_message.yml
@@ -1,0 +1,44 @@
+test_cases:
+  - test_case: user_corrects_recipient_in_the_next_message
+    steps:
+      - user: I want to transfer money
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: Sorry, I meant to say Joe
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Joe
+          - bot_uttered:
+              utter_name: utter_corrected_previous_input
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: "50"
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "50"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transfer_complete
+            - flow_completed:
+                flow_id: transfer_money

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_recipient_late.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_recipient_late.yml
@@ -1,0 +1,44 @@
+test_cases:
+  - test_case: user_corrects_recipient_late
+    steps:
+      - user: I want to transfer money
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: 50 USD
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "50"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user:  Oh wait, I want to send it to James!
+        assertions:
+            - flow_started: pattern_correction
+            - bot_uttered:
+                utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: James
+          - bot_uttered:
+              utter_name: utter_corrected_previous_input
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transfer_complete
+            - flow_completed:
+                flow_id: transfer_money

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_slot_with_nlu_based_mapping.yml
@@ -1,0 +1,244 @@
+test_cases:
+  - test_case: user_orders_pizza_stating_which_type_and_corrects_quantity_later
+    steps:
+      - user: I would like to order a diavola pizza.
+        assertions:
+            - slot_was_set:
+                - name: pizza
+                  value: diavola
+            - bot_uttered:
+                utter_name: utter_ask_num_pizza
+      - user: 1 please
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 1
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 30 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 30 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+      - user: actually can i get 2 pizzas instead
+        assertions:
+            - flow_started: pattern_correction
+            - bot_uttered:
+                utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 2
+            - bot_uttered:
+                utter_name: utter_corrected_previous_input
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+
+  - test_case: user_orders_pizza_stating_which_type_and_corrects_pizza_type_later
+    steps:
+      - user: I would like to order a diavola pizza.
+        assertions:
+            - slot_was_set:
+                - name: pizza
+                  value: diavola
+            - bot_uttered:
+                utter_name: utter_ask_num_pizza
+      - user: 1 please
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 1
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 30 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 30 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+      - user: actually can i get a margherita instead
+        assertions:
+            - flow_started: pattern_correction
+            - bot_uttered:
+                utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+            - slot_was_set:
+                - name: pizza
+                  value: margherita
+            - bot_uttered:
+                utter_name: utter_corrected_previous_input
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+
+  - test_case: user_orders_pizza_stating_which_type_and_corrects_address_later
+    steps:
+      - user: I would like to order a diavola pizza.
+        assertions:
+            - slot_was_set:
+                - name: pizza
+                  value: diavola
+            - bot_uttered:
+                utter_name: utter_ask_num_pizza
+      - user: 1 please
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 1
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 31 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 31 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+      - user: wait, i meant to say the pizza should be delivered to 13 Pine Road.
+        assertions:
+            - bot_uttered:
+                text_matches: "I'm sorry about that. Let's correct your address. Please confirm your new address?"
+            - slot_was_set:
+                - name: address
+                  value: null
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 13 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 13 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+
+  - test_case: user_orders_pizza_stating_which_type_and_corrects_payment_option_later
+    steps:
+      - user: I would like to order a diavola pizza.
+        assertions:
+            - slot_was_set:
+                - name: pizza
+                  value: diavola
+            - bot_uttered:
+                utter_name: utter_ask_num_pizza
+      - user: 1 please
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 1
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 30 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 30 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+      - user: loyalty points
+        assertions:
+            - slot_was_set:
+                - name: payment_option
+                  value: membership_points
+            - flow_started: authenticate_user
+            - bot_uttered:
+                utter_name: utter_ask_user_name
+      - user: actually can i pay with a credit card
+        assertions:
+            - flow_started: pattern_correction
+            - bot_uttered:
+                utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+            - slot_was_set:
+                - name: payment_option
+                  value: card
+            - bot_uttered:
+                utter_name: utter_corrected_previous_input
+            - bot_uttered:
+                utter_name: utter_ask_card_details
+
+  - test_case: user_orders_pizza_stating_which_type_and_corrects_order_details_later
+    steps:
+      - user: I would like to order a diavola pizza.
+        assertions:
+            - slot_was_set:
+                - name: pizza
+                  value: diavola
+            - bot_uttered:
+                utter_name: utter_ask_num_pizza
+      - user: 1 please
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 1
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 30 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 30 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+      - user: actually, i made a mistake and need to update my delivery address first.
+        assertions:
+            - bot_uttered:
+                text_matches: "I'm sorry about that. Let's correct your order. What would you like to change?"
+                buttons:
+                  - title: Pizza
+                    payload: /SetSlots(pizza=null)
+                  - title: Quantity
+                    payload: /SetSlots(num_pizza=null)
+                  - title: Address
+                    payload: /SetSlots(address=null)
+      - user: /SetSlots(address=null)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 3 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 3 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_payment_option

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_string_slot.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_string_slot.yml
@@ -1,0 +1,45 @@
+test_cases:
+  - test_case: user_corrects_string_slot
+    steps:
+      # NLUCommandAdapter should start the flow, so "Peter" is not detected as an entity
+      - user: I want to add Peter to my contacts
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_handle
+      - user: It's @PeterPark
+        assertions:
+          - slot_was_set:
+              - name: add_contact_handle
+                value: "@PeterPark"
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_name
+      - user: Peter
+        assertions:
+          - slot_was_set:
+              - name: add_contact_name
+                value: "Peter"
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_confirmation
+      - user: Ah, please use Spidey as the name
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+            - slot_was_set:
+                - name: add_contact_name
+                  value: "Spidey"
+            - bot_uttered:
+                utter_name: utter_corrected_previous_input
+            - bot_uttered:
+                utter_name: utter_ask_add_contact_confirmation
+      - user: "yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_contact_added
+            - flow_completed:
+                flow_id: add_contact

--- a/e2e_tests_with_assertions/passing/corrections/user_corrects_twice_in_row.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_corrects_twice_in_row.yml
@@ -1,0 +1,29 @@
+test_cases:
+  - test_case: user_corrects_twice_in_row
+    steps:
+      - user: I want to send money to Joe
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: oh sorry I meant John
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: damn, should be Alex
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Alex
+          - bot_uttered:
+              utter_name: utter_corrected_previous_input
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money

--- a/e2e_tests_with_assertions/passing/corrections/user_resets_a_slot_by_slot_name.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_resets_a_slot_by_slot_name.yml
@@ -1,0 +1,38 @@
+test_cases:
+  - test_case: user_resets_a_slot_by_slot_name
+    steps:
+      - user: I want to send some money to John
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: "50"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: I want to change the recipient
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_corrected_previous_input
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_recipient
+      - user: Eliza
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Eliza
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transfer_complete
+            - flow_completed:
+                flow_id: transfer_money

--- a/e2e_tests_with_assertions/passing/corrections/user_resets_a_slot_by_value.yml
+++ b/e2e_tests_with_assertions/passing/corrections/user_resets_a_slot_by_value.yml
@@ -1,0 +1,36 @@
+test_cases:
+  - test_case: user_resets_a_slot_by_value
+    steps:
+      - user: I want to send some money to John
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: Sorry, I didn't mean John
+        assertions:
+          - flow_started: pattern_correction
+          - bot_uttered:
+              utter_name: utter_ask_confirm_slot_correction
+      - user: /SetSlots(confirm_slot_correction=true)
+        assertions:
+            - bot_uttered:
+                utter_name: utter_corrected_previous_input
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_recipient
+      - user: to Joe
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Joe
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: "50"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/digressions/intermittent_flow_switch.yml
+++ b/e2e_tests_with_assertions/passing/digressions/intermittent_flow_switch.yml
@@ -1,0 +1,28 @@
+test_cases:
+  - test_case: user makes an intermittent flow switch
+    steps:
+    - user: I need to transfer some money to John
+      assertions:
+        - slot_was_set:
+            - name: route_session_to_calm
+              value: True
+        - bot_uttered:
+            utter_name: utter_ask_transfer_money_amount_of_money
+    - user: How much do I have on my account?
+      assertions:
+        - bot_uttered:
+            utter_name: utter_current_balance
+        - bot_uttered:
+            utter_name: utter_flow_continue_interrupted
+        - bot_uttered:
+            utter_name: utter_ask_transfer_money_amount_of_money
+    - user: ah, great, I owe him $500
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_transfer_money_final_confirmation
+    - user: "yes"
+      assertions:
+        - bot_uttered:
+            utter_name: utter_transfer_complete
+        - bot_uttered:
+            utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/digressions/user_answers_and_also_asks_a_question.yml
+++ b/e2e_tests_with_assertions/passing/digressions/user_answers_and_also_asks_a_question.yml
@@ -1,0 +1,15 @@
+test_cases:
+  - test_case: user answers and also asks a question
+    steps:
+      - user: I want to send 50$ to Justin
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: yes, and btw are there any fees associated with the sending?
+        assertions:
+          # not able to test the response of enterprise search yet
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/digressions/user_asks_for_a_moment_to_think.yml
+++ b/e2e_tests_with_assertions/passing/digressions/user_asks_for_a_moment_to_think.yml
@@ -1,0 +1,21 @@
+test_cases:
+  - test_case: user asks for a moment to think
+    steps:
+      - user: I want to send money to Yizhi
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: one moment
+        assertions:
+            - bot_uttered:
+                utter_name: utter_take_your_time
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: "100"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "Yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/digressions/user_asks_what_info_is.yml
+++ b/e2e_tests_with_assertions/passing/digressions/user_asks_what_info_is.yml
@@ -1,0 +1,34 @@
+test_cases:
+  - test_case: user asks what requested information is
+    steps:
+      # NLUCommandAdapter should start the flow, so "Peter" is not detected as an entity
+      - user: I want to add Kate to my contacts
+        assertions:
+            - slot_was_set:
+                - name: route_session_to_calm
+                  value: True
+            - bot_uttered:
+                utter_name: utter_ask_add_contact_handle
+      - user: What's a contact handle?
+        assertions:
+            # not able to test the response of enterprise search
+            - bot_uttered:
+                utter_name: utter_ask_add_contact_handle
+      - user: Ah okay she sent it to me, it's @KatePurry
+        assertions:
+            - slot_was_set:
+                - name: add_contact_handle
+                  value: "@KatePurry"
+            - bot_uttered:
+                utter_name: utter_ask_add_contact_name
+      - user: Kate
+        assertions:
+          - slot_was_set:
+              - name: add_contact_name
+                value: "Kate"
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_contact_added

--- a/e2e_tests_with_assertions/passing/digressions/user_asks_why_information_is_needed.yml
+++ b/e2e_tests_with_assertions/passing/digressions/user_asks_why_information_is_needed.yml
@@ -1,0 +1,28 @@
+test_cases:
+  - test_case: user asks why information is needed
+    steps:
+      - user: I want to verify my account
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: It's a.tweep@twitter.com
+        assertions:
+        - bot_uttered:
+            utter_name: utter_ask_based_in_california
+      - user: Why do you need to know this?
+        assertions:
+          - bot_uttered:
+              utter_name: utter_california_compliance
+          - bot_uttered:
+              utter_name: utter_ask_based_in_california
+      - user: "No"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_confirmation
+      - user: "Yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_verify_account_success

--- a/e2e_tests_with_assertions/passing/digressions/user_refuses_to_provide_information.yml
+++ b/e2e_tests_with_assertions/passing/digressions/user_refuses_to_provide_information.yml
@@ -1,0 +1,28 @@
+test_cases:
+  - test_case: user refuses to provide information
+    steps:
+      - user: I want to verify my account
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: It's thomas@x.com
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_based_in_california
+      - user: "Yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_sufficient_california_income
+      - user: Why is that your business?
+        assertions:
+          - bot_uttered:
+              utter_name: utter_california_compliance
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_sufficient_california_income
+      - user: never mind then!!
+        assertions:
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/digressions/user_starts_multiple_flows.yml
+++ b/e2e_tests_with_assertions/passing/digressions/user_starts_multiple_flows.yml
@@ -1,0 +1,12 @@
+test_cases:
+  - test_case: user starts multiple flows
+    steps:
+      - user: Show my transactions and send money
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_transactions
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient

--- a/e2e_tests_with_assertions/passing/digressions/user_starts_with_a_very_long_message.yml
+++ b/e2e_tests_with_assertions/passing/digressions/user_starts_with_a_very_long_message.yml
@@ -1,0 +1,12 @@
+test_cases:
+  - test_case: user starts with a very long message
+    steps:
+      - user: What's up dawg, my homie Steven got my back yesterday when we were out for drinks and my phone was out of batt, let me settle up with him.
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Steven
+              - name: route_session_to_calm
+                value: True
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money

--- a/e2e_tests_with_assertions/passing/digressions/validation_too_little_money.yml
+++ b/e2e_tests_with_assertions/passing/digressions/validation_too_little_money.yml
@@ -1,0 +1,20 @@
+test_cases:
+  - test_case: validation too little money
+    steps:
+      - user: I want to send 5000$ to Martin
+        assertions:
+            - slot_was_set:
+                - name: route_session_to_calm
+                  value: True
+            - bot_uttered:
+                utter_name: utter_transfer_money_insufficient_funds
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: Oh, I thought I had more, then do 3000$ for now
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/disambiguation/user_sends_short_noun_only_message.yml
+++ b/e2e_tests_with_assertions/passing/disambiguation/user_sends_short_noun_only_message.yml
@@ -1,0 +1,18 @@
+# BUG: WAITING FOR https://rasahq.atlassian.net/browse/ENG-1091
+
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user sends short noun only message
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: cash
+        assertions:
+          - pattern_clarification_contains:
+              - 'transfer money'
+              - 'check your balance'
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa

--- a/e2e_tests_with_assertions/passing/disambiguation/user_sends_short_verb_only_message.yml
+++ b/e2e_tests_with_assertions/passing/disambiguation/user_sends_short_verb_only_message.yml
@@ -1,0 +1,20 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user sends short verb only message
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: add
+        assertions:
+        - pattern_clarification_contains:
+            - 'add a card'
+            - 'add a contact'
+        - bot_uttered:
+            utter_name: utter_clarification_options_rasa
+      - user: contact
+        assertions:
+        - bot_uttered:
+            utter_name: utter_ask_add_contact_handle

--- a/e2e_tests_with_assertions/passing/disambiguation/user_sends_short_verb_only_message.yml
+++ b/e2e_tests_with_assertions/passing/disambiguation/user_sends_short_verb_only_message.yml
@@ -13,8 +13,4 @@ test_cases:
             - 'add a card'
             - 'add a contact'
         - bot_uttered:
-            utter_name: utter_clarification_options_rasa
-      - user: contact
-        assertions:
-        - bot_uttered:
             utter_name: utter_ask_add_contact_handle

--- a/e2e_tests_with_assertions/passing/flow_guards/user_is_referred_to_human_after_2_clarifications.yml
+++ b/e2e_tests_with_assertions/passing/flow_guards/user_is_referred_to_human_after_2_clarifications.yml
@@ -1,0 +1,46 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+metadata:
+- duplicate_message_1:
+    turn_idx: 1
+- duplicate_message_2:
+    turn_idx: 2
+- duplicate_message_3:
+    turn_idx: 3
+
+test_cases:
+  - test_case: user_is_referred_to_human_after_2_clarifications
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: cash
+        metadata: duplicate_message_1
+        assertions:
+          - pattern_clarification_contains:
+              - 'transfer money'
+              - 'check your balance'
+          - slot_was_set: 
+            - name: clarification_count
+              value: 1
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: cash
+        metadata: duplicate_message_2
+        assertions:
+          - pattern_clarification_contains:
+              - 'transfer money'
+              - 'check your balance'
+          - slot_was_set: 
+            - name: clarification_count
+              value: 2
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: cash
+        metadata: duplicate_message_3
+        assertions:
+          - slot_was_set: 
+            - name: clarification_count
+              value: 3
+          - flow_started: pattern_human_handoff

--- a/e2e_tests_with_assertions/passing/flow_guards/user_is_referred_to_human_after_3_portfolio_check_auth_fails.yml
+++ b/e2e_tests_with_assertions/passing/flow_guards/user_is_referred_to_human_after_3_portfolio_check_auth_fails.yml
@@ -1,0 +1,63 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+metadata:
+- duplicate_message_1:
+    turn_idx: 1
+- duplicate_message_2:
+    turn_idx: 2
+- duplicate_message_3:
+    turn_idx: 3
+
+test_cases:
+  - test_case: user_is_referred_to_human_after_3_portfolio_check_auth_fails
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: I want to check my portfolio
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_name
+      - user: John
+        metadata: duplicate_message_1
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_password
+      - user: "1234"
+        metadata: duplicate_message_1
+        assertions:
+          - bot_uttered: 
+              utter_name: utter_authentication_failed
+          - slot_was_set: 
+            - name: login_failed_attempts
+              value: 1
+          - bot_uttered:
+              utter_name: utter_ask_user_name
+      - user: John
+        metadata: duplicate_message_2
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_password
+      - user: "1234"
+        metadata: duplicate_message_2
+        assertions:
+          - bot_uttered: 
+              utter_name: utter_authentication_failed
+          - slot_was_set: 
+            - name: login_failed_attempts
+              value: 2
+          - bot_uttered:
+              utter_name: utter_ask_user_name
+      - user: John
+        metadata: duplicate_message_3
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_password
+      - user: "1234"
+        metadata: duplicate_message_3
+        assertions:
+          - slot_was_set: 
+            - name: login_failed_attempts
+              value: 3
+          - flow_started: pattern_human_handoff

--- a/e2e_tests_with_assertions/passing/flow_guards/user_tries_to_register_to_vote_in_california.yml
+++ b/e2e_tests_with_assertions/passing/flow_guards/user_tries_to_register_to_vote_in_california.yml
@@ -1,0 +1,43 @@
+metadata:
+  - duplicate_msg_1:
+      turn_idx: 1
+  - duplicate_msg_2:
+      turn_idx: 2
+  - duplicate_msg_3:
+      turn_idx: 3
+
+test_cases:
+
+  - test_case: user is based in california and wants to register to vote
+    steps:
+    - user: I would like to verify my account.
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_verify_account_email
+    - user: sam@microsoft.com
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_based_in_california
+    - user: "yes"
+      metadata: duplicate_msg_1
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_verify_account_sufficient_california_income
+    - user: "yes"
+      metadata: duplicate_msg_2
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_verify_account_confirmation
+    - user: "yes"
+      metadata: duplicate_msg_3
+      assertions:
+        - bot_uttered:
+            utter_name: utter_verify_account_success
+        - bot_uttered:
+            utter_name: utter_can_do_something_else
+    - user: I would like to register to vote in california.
+      assertions:
+        - bot_uttered:
+            utter_name: utter_register_to_vote_in_california
+        - bot_uttered:
+            utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/happy_path/user_adds_contact_to_their_list.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_adds_contact_to_their_list.yml
@@ -1,0 +1,21 @@
+test_cases:
+  - test_case: user_adds_contact_to_their_list
+    steps:
+      - user: I want to add someone to my contact list
+        assertions:
+          - bot_uttered:
+                utter_name: utter_ask_add_contact_handle
+      - user: it's @barts
+        assertions:
+          - slot_was_set:
+                - name: add_contact_handle
+                  value: "@barts"
+          - bot_uttered:
+                utter_name: utter_ask_add_contact_name
+      - user: just Bart
+        assertions:
+          - slot_was_set:
+                - name: add_contact_name
+                  value: Bart
+          - bot_uttered:
+                utter_name: utter_ask_add_contact_confirmation

--- a/e2e_tests_with_assertions/passing/happy_path/user_books_a_restaurant.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_books_a_restaurant.yml
@@ -1,0 +1,38 @@
+test_cases:
+  - test_case: user_books_a_restaurant
+    steps:
+    - user: book a restaurant
+      assertions:
+        - slot_was_set:
+            - name: route_session_to_calm
+              value: False
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_city
+    - user: /inform{"location":"amsterdam"}
+      assertions:
+        - bot_uttered:
+            text_matches: "What cuisine are you looking for?"
+    - user: /inform{"cuisine":"Thai"}
+      assertions:
+        - slot_was_set:
+            - name: cuisine
+              value: Thai
+        - bot_uttered:
+            text_matches: "Do you know which restaurant you would like me to reserve a table at?"
+    - user: /inform{"restaurant_name":"Thai Spice"}
+      assertions:
+        - slot_was_set:
+            - name: restaurant_name
+              value: Thai Spice
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_num_people
+    - user: "3"
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_restaurant_time
+    - user: Next Wednesday at 6pm
+      assertions:
+        - bot_uttered:
+            utter_name: utter_restaurant_form_submit
+        - bot_uttered:
+            utter_name: utter_restaurant_available

--- a/e2e_tests_with_assertions/passing/happy_path/user_books_a_restaurant_with_an_alternative_time.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_books_a_restaurant_with_an_alternative_time.yml
@@ -1,0 +1,27 @@
+test_cases:
+  - test_case: user_books_a_restaurant_with_an_alternative_time
+    steps:
+    - user: I want to book a table for 3 people for tomorrow
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_city
+    - user: /inform{"location":"berlin"}
+      assertions:
+        - bot_uttered:
+            text_matches: "What cuisine are you looking for?"
+    - user: /inform{"cuisine":"Japanese"}
+      assertions:
+        - bot_uttered:
+            text_matches: "Do you know which restaurant you would like me to reserve a table at?"
+    - user: Ah, wait. John just texted me, we need to move the date to Wednesday, 6pm.
+      assertions:
+        - slot_was_set:
+            - name: restaurant_time
+        - bot_uttered:
+            text_matches: "Do you know which restaurant you would like me to reserve a table at?"
+    - user: /inform{"restaurant_name":"Sakura Sushi House"}
+      assertions:
+        - bot_uttered:
+            utter_name: utter_restaurant_form_submit
+        - bot_uttered:
+            utter_name: utter_restaurant_available

--- a/e2e_tests_with_assertions/passing/happy_path/user_books_restaurant_with_fixed_date_indirect.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_books_restaurant_with_fixed_date_indirect.yml
@@ -1,0 +1,21 @@
+test_cases:
+  - test_case: user_books_restaurant_with_fixed_date_indirect
+    steps:
+    - user: I want to book a table for two 7pm tonight
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_restaurant_form_city
+    - user: /inform{"location":"berlin"}
+      assertions:
+        - bot_uttered:
+            text_matches: "What cuisine are you looking for?"
+    - user: /inform{"cuisine":"French"}
+      assertions:
+        - bot_uttered:
+            text_matches: "Do you know which restaurant you would like me to reserve a table at?"
+    - user: /inform{"restaurant_name":"Le Gourmet"}
+      assertions:
+        - bot_uttered:
+            utter_name: utter_restaurant_form_submit
+        - bot_uttered:
+            utter_name: utter_restaurant_available

--- a/e2e_tests_with_assertions/passing/happy_path/user_checks_balance.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_checks_balance.yml
@@ -1,0 +1,9 @@
+test_cases:
+  - test_case: user_checks_balance
+    steps:
+      - user: Show my balance
+        assertions:
+          - bot_uttered:
+              utter_name: utter_current_balance
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/happy_path/user_checks_balance_then_transactions.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_checks_balance_then_transactions.yml
@@ -1,0 +1,13 @@
+test_cases:
+  - test_case: user_checks_balance_then_transactions
+    steps:
+      - user: Show my balance
+        assertions:
+            - bot_uttered:
+                utter_name: utter_current_balance
+            - bot_uttered:
+                utter_name: utter_can_do_something_else
+      - user: Show my transactions please
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transactions

--- a/e2e_tests_with_assertions/passing/happy_path/user_checks_portfolio.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_checks_portfolio.yml
@@ -1,0 +1,27 @@
+test_cases:
+  - test_case: user_checks_portfolio
+    steps:
+      - user: I want to check my portfolio
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_name
+      - user: Max
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_password
+      - user: "1234"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_authentication_successful
+          - bot_uttered:
+              utter_name: utter_ask_portfolio_type
+      - user: /SetSlots(portfolio_type=mutual_funds)
+        assertions:
+          - slot_was_set:
+              - name: portfolio_type
+                value: mutual_funds
+              - name: portfolio_exists
+                value: True
+              - name: portfolio_options
+          - bot_uttered:
+              utter_name: utter_portfolio_options_found

--- a/e2e_tests_with_assertions/passing/happy_path/user_checks_portfolio_mentioning_type_upfront.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_checks_portfolio_mentioning_type_upfront.yml
@@ -1,0 +1,25 @@
+test_cases:
+  - test_case: user_checks_portfolio_mentioning_type_upfront
+    steps:
+      - user: I want to check my bonds portfolio
+        assertions:
+            - slot_was_set:
+                - name: portfolio_type
+                  value: bonds
+            - bot_uttered:
+                utter_name: utter_ask_user_name
+      - user: Max
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_user_password
+      - user: "1234"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_authentication_successful
+            - slot_was_set:
+                - name: portfolio_exists
+                  value: True
+                - name: portfolio_options
+            - bot_uttered:
+                utter_name: utter_portfolio_options_found
+

--- a/e2e_tests_with_assertions/passing/happy_path/user_checks_their_transactions.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_checks_their_transactions.yml
@@ -1,0 +1,7 @@
+test_cases:
+  - test_case: user_checks_their_transactions
+    steps:
+      - user: Show my transactions please
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transactions

--- a/e2e_tests_with_assertions/passing/happy_path/user_fills_resetting_slot.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_fills_resetting_slot.yml
@@ -1,0 +1,33 @@
+test_cases:
+  - test_case: user fills resetting slot (account_email) and non-resetting slot (based_in_california).
+    steps:
+      - user: I would like to confirm my account
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: gos@hawk.com
+        assertions:
+            - slot_was_set:
+                - name: verify_account_email
+                  value: gos@hawk.com
+            - bot_uttered:
+                utter_name: utter_ask_based_in_california
+      - user: "no"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_verify_account_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_verify_account_success
+          # Check that the slot was reset at the end of the flow
+          - slot_was_set:
+              - name: verify_account_email
+                value: null
+              - name: verify_account_confirmation
+                value: null
+          # Check that the slot was not reset at the end of the flow
+          - slot_was_not_set:
+              - name: based_in_california
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/happy_path/user_orders_pizza.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_orders_pizza.yml
@@ -1,0 +1,120 @@
+test_cases:
+  - test_case: user_orders_pizza_stating_which_type_and_pays_with_card
+    steps:
+      - user: I would like to order a diavola pizza.
+        assertions:
+            - slot_was_set:
+                - name: pizza
+                  value: diavola
+            - bot_uttered:
+                utter_name: utter_ask_num_pizza
+      - user: 2 please
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 2
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 30 Pine Road
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 30 Pine Road
+            - bot_uttered:
+                utter_name: utter_confirm
+                buttons:
+                  - title: Yes
+                    payload: /SetSlots(confirmation_order=True)
+                  - title: No
+                    payload: /SetSlots(confirmation_order=False)
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - slot_was_set:
+                - name: confirmation_order
+                  value: True
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+      - user: credit card
+        assertions:
+            - slot_was_set:
+                - name: payment_option
+                  value: card
+            - bot_uttered:
+                utter_name: utter_ask_card_details
+      - user: 1234 5678 9012 3456
+        assertions:
+            - slot_was_set:
+                - name: card_details
+                  value: 1234 5678 9012 3456
+            - bot_uttered:
+                utter_name: utter_execute_payment
+
+  - test_case: user_orders_pizza_stating_which_type_and_pays_with_points
+    steps:
+      - user: I would like to order a diavola pizza.
+        assertions:
+          - slot_was_set:
+              - name: pizza
+                value: diavola
+          - bot_uttered:
+              utter_name: utter_ask_num_pizza
+      - user: 1 please
+        assertions:
+            - slot_was_set:
+                - name: num_pizza
+                  value: 1
+            - bot_uttered:
+                utter_name: utter_ask_address
+      - user: 40 Elm Street
+        assertions:
+            - slot_was_set:
+                - name: address
+                  value: 40 Elm Street
+            - bot_uttered:
+                utter_name: utter_confirm
+                buttons:
+                  - title: Yes
+                    payload: /SetSlots(confirmation_order=True)
+                  - title: No
+                    payload: /SetSlots(confirmation_order=False)
+      - user: /SetSlots(confirmation_order=True)
+        assertions:
+            - slot_was_set:
+                - name: confirmation_order
+                  value: True
+            - bot_uttered:
+                utter_name: utter_ask_payment_option
+      - user: loyalty points
+        assertions:
+            - slot_was_set:
+                - name: payment_option
+                  value: membership_points
+            - flow_started: authenticate_user
+            - bot_uttered:
+                utter_name: utter_ask_user_name
+      - user: janedoe
+        assertions:
+            - slot_was_set:
+                - name: user_name
+                  value: janedoe
+            - bot_uttered:
+                utter_name: utter_ask_user_password
+      - user: r@nd0m
+        assertions:
+            - slot_was_set:
+                - name: user_password
+                  value: r@nd0m
+            - bot_uttered:
+                utter_name: utter_authentication_successful
+            - flow_completed:
+                 flow_id: authenticate_user
+            - action_executed: action_check_points
+            - bot_uttered:
+                 text_matches: "You have 150 points in your membership account. That's enough to get a free pizza!"
+            - flow_completed:
+               flow_id: use_membership_points
+            - bot_uttered:
+                utter_name: utter_execute_payment
+            - flow_completed:
+                flow_id: order_pizza
+

--- a/e2e_tests_with_assertions/passing/happy_path/user_remove_contact.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_remove_contact.yml
@@ -1,0 +1,19 @@
+test_cases:
+  - test_case: user_remove_contact
+    steps:
+      - user: Remove contact
+        assertions:
+        - bot_uttered:
+            text_matches: "What's the handle of the user you want to remove?"
+      - user: "@MaryLu"
+        assertions:
+          - slot_was_set:
+              - name: remove_contact_handle
+                value: "@MaryLu"
+          - bot_uttered:
+              utter_name: utter_ask_remove_contact_confirmation
+      - user: "Yes"
+        assertions:
+          - action_executed: remove_contact
+          - bot_uttered:
+              utter_name: utter_remove_contact_success

--- a/e2e_tests_with_assertions/passing/happy_path/user_remove_contact_from_list.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_remove_contact_from_list.yml
@@ -1,0 +1,27 @@
+test_cases:
+  - test_case: user_remove_contact_from_list
+    steps:
+      - user: Please show my contacts
+        assertions:
+            - bot_uttered:
+                utter_name: utter_list_contacts
+            - bot_uttered:
+                utter_name: utter_can_do_something_else
+      # The NLUCommandAdapter predicts the StartFlow(remove_contact) so the contact handle is not yet detected
+      - user: Remove contact @MaryLu
+        assertions:
+            - flow_started: remove_contact
+            - bot_uttered:
+                text_matches: "What's the handle of the user you want to remove?"
+      - user: "@MaryLu"
+        assertions:
+          - slot_was_set:
+              - name: remove_contact_handle
+                value: "@MaryLu"
+          - bot_uttered:
+              utter_name: utter_ask_remove_contact_confirmation
+      - user: "yes"
+        assertions:
+          - action_executed: remove_contact
+          - bot_uttered:
+              utter_name: utter_remove_contact_success

--- a/e2e_tests_with_assertions/passing/happy_path/user_replace_card_incorrect_card.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_replace_card_incorrect_card.yml
@@ -1,0 +1,14 @@
+test_cases:
+  - test_case: user_replace_card_incorrect_card
+    steps:
+      - user: I need to replace my card
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_confirm_correct_card
+      - user: "no"
+        assertions:
+          - slot_was_set:
+              - name: confirm_correct_card
+                value: false
+          - bot_uttered:
+              utter_name: utter_relevant_card_not_linked

--- a/e2e_tests_with_assertions/passing/happy_path/user_replace_card_with_linked_flow.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_replace_card_with_linked_flow.yml
@@ -1,0 +1,120 @@
+metadata:
+  - duplicate_replace_card_1:
+      turn_idx: 1
+  - duplicate_replace_card_2:
+      turn_idx: 2
+test_cases:
+  - test_case: Replace lost card which was used fraudulently
+    steps:
+      - user: I need to replace my card
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_confirm_correct_card
+      - user: "yes"
+        metadata: duplicate_replace_card_1
+        assertions:
+          - slot_was_set:
+              - name: confirm_correct_card
+                value: true
+          - bot_uttered:
+              utter_name: utter_ask_replacement_reason
+      - user: I lost my card
+        assertions:
+          - slot_was_set:
+              - name: replacement_reason
+                value: lost
+          - bot_uttered:
+              utter_name: utter_ask_was_card_used_fraudulently
+      - user: "yes"
+        metadata: duplicate_replace_card_2
+        assertions:
+          - slot_was_set:
+              - name: was_card_used_fraudulently
+                value: true
+          - bot_uttered:
+              utter_name: utter_report_fraud
+
+  - test_case: Replace lost card which was not used fraudulently
+    steps:
+      - user: I need to replace my card
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_confirm_correct_card
+      - user: "yes"
+        assertions:
+            - slot_was_set:
+                - name: confirm_correct_card
+                  value: true
+            - bot_uttered:
+                utter_name: utter_ask_replacement_reason
+      - user: I lost my card
+        assertions:
+          - slot_was_set:
+              - name: replacement_reason
+                value: lost
+          - bot_uttered:
+              utter_name: utter_ask_was_card_used_fraudulently
+      - user: "no"
+        assertions:
+          - slot_was_set:
+              - name: was_card_used_fraudulently
+                value: false
+          - bot_uttered:
+              utter_name: utter_will_cancel_and_send_new
+          - bot_uttered:
+              utter_name: utter_new_card_has_been_ordered
+
+  - test_case: Replace damaged card
+    steps:
+      - user: I need to replace my card
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_confirm_correct_card
+      - user: "yes"
+        assertions:
+            - slot_was_set:
+                - name: confirm_correct_card
+                  value: true
+            - bot_uttered:
+                utter_name: utter_ask_replacement_reason
+      - user: My card is damaged
+        assertions:
+          - slot_was_set:
+              - name: replacement_reason
+                value: damaged
+          - bot_uttered:
+              utter_name: utter_will_cancel_and_send_new
+          - bot_uttered:
+              utter_name: utter_new_card_has_been_ordered
+
+  - test_case: Replace card with unknown replacement reason
+    steps:
+    - user: I need to replace my card
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_confirm_correct_card
+    - user: "yes"
+      assertions:
+        - slot_was_set:
+            - name: confirm_correct_card
+              value: true
+        - bot_uttered:
+            utter_name: utter_ask_replacement_reason
+    - user: some other reason
+      assertions:
+            - slot_was_set:
+                - name: replacement_reason
+                  # we cannot specify the original user value because the LLM can extract variable values
+                  # however the slot should be reset as part of running the slot rejections, which
+                  # is why we set the value to null
+            - slot_was_set:
+                - name: replacement_reason
+                  value: null
+            - bot_uttered:
+                utter_name: utter_categorical_slot_rejection
+            - bot_uttered:
+                utter_name: utter_ask_replacement_reason
+    - user: ok, stop then
+      assertions:
+            - bot_uttered:
+                utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/happy_path/user_replace_card_with_linked_flow.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_replace_card_with_linked_flow.yml
@@ -101,6 +101,7 @@ test_cases:
         - bot_uttered:
             utter_name: utter_ask_replacement_reason
     - user: some other reason
+      assertion_order_enabled: true
       assertions:
             - slot_was_set:
                 - name: replacement_reason

--- a/e2e_tests_with_assertions/passing/happy_path/user_search_hotel.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_search_hotel.yml
@@ -1,0 +1,62 @@
+metadata:
+  - german_hotel_search:
+      hotel_name: Steigenberger Hotel
+      hotel_average_rating: 3
+  - uk_hotel_search:
+      hotel_name: Britannia International Hotel
+      hotel_average_rating: 4
+  - updated_rating:
+      hotel_average_rating: 8.5
+
+test_cases:
+  - test_case: user searches for hotels with no metadata
+    steps:
+      - user: I want to search for hotels
+        assertions:
+          - slot_was_set:
+              - name: hotel_name
+                value: "Shadyside Inn"
+              - name: hotel_average_rating
+                value: 2
+          - bot_uttered:
+              utter_name: utter_hotel_inform_rating
+
+  - test_case: user searches for hotels with test_case metadata
+    metadata: german_hotel_search
+    steps:
+      - user: I want to search for hotels
+        assertions:
+          - slot_was_set:
+              - name: hotel_name
+                value: "Steigenberger Hotel"
+              - name: hotel_average_rating
+                value: 3
+          - bot_uttered:
+              utter_name: utter_hotel_inform_rating
+
+  - test_case: user searches for hotels with user step metadata
+    steps:
+      - user: I want to search for hotels
+        metadata: uk_hotel_search
+        assertions:
+            - slot_was_set:
+                  - name: hotel_name
+                    value: "Britannia International Hotel"
+                  - name: hotel_average_rating
+                    value: 4
+            - bot_uttered:
+                  utter_name: utter_hotel_inform_rating
+
+  - test_case: user searches for hotels with test_case and user step metadata
+    metadata: german_hotel_search
+    steps:
+      - user: I want to search for hotels
+        metadata: updated_rating
+        assertions:
+          - slot_was_set:
+              - name: hotel_name
+                value: "Steigenberger Hotel"
+              - name: hotel_average_rating
+                value: 8.5
+          - bot_uttered:
+              utter_name: utter_hotel_inform_rating

--- a/e2e_tests_with_assertions/passing/happy_path/user_sets_up_recurrent_payment.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_sets_up_recurrent_payment.yml
@@ -1,0 +1,122 @@
+test_cases:
+  - test_case: user_wants_to_set_up_a_new_recurrent_payment_without_stating_which_type
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_type
+      - user: direct debit
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_type
+                value: direct debit
+          - bot_uttered:
+              utter_name: utter_ask_recipient
+      - user: Jane Doe
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_recipient
+                value: Jane Doe
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_amount_of_money
+      - user: 100 euros
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_amount_of_money
+                value: 100.0
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_frequency
+      - user: monthly
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_frequency
+                value: monthly
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_start_date
+      - user: Jan 1st, 2050
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_start_date
+                value: "2050-01-01"
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_end_date
+      - user: Jan 1st, 2051
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_end_date
+                value: "2051-01-01"
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_confirmation
+      - user: "Yes"
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_confirmation
+                value: true
+          - bot_uttered:
+              utter_name: utter_payment_complete
+
+  - test_case: user wants to set up a new recurrent payment, stating first which type of payment
+    steps:
+      - user: I want to set up a new standing order payment.
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_type
+                value: standing order
+          - bot_uttered:
+              utter_name: utter_ask_recipient
+
+  - test_case: user wants to set up a new recurrent payment, but specifies the type incompletely
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_type
+      - user: direct
+        assertions:
+            - slot_was_set:
+                - name: recurrent_payment_type
+                  value: direct debit
+            - bot_uttered:
+                utter_name: utter_ask_recipient
+
+  - test_case: user wants to set up a new recurrent payment, but specifies the type incompletely, example 2
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_type
+      - user: d debit
+        assertions:
+            - slot_was_set:
+                - name: recurrent_payment_type
+                  value: direct debit
+            - bot_uttered:
+                utter_name: utter_ask_recipient
+
+  - test_case: user wants to set up a new recurrent payment, but specifies over specifies the type
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_type
+      - user: direct debit transfer payment
+        assertions:
+            - slot_was_set:
+                - name: recurrent_payment_type
+                  value: direct debit
+            - bot_uttered:
+                utter_name: utter_ask_recipient
+
+  - test_case: user wants to set up a new recurrent payment, but specifies the type with spelling mistakes
+    steps:
+      - user: I want to set up a new recurrent payment
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_type
+      - user: direct debt
+        assertions:
+            - slot_was_set:
+                - name: recurrent_payment_type
+                  value: direct debit
+            - bot_uttered:
+                utter_name: utter_ask_recipient

--- a/e2e_tests_with_assertions/passing/happy_path/user_transfer_money.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_transfer_money.yml
@@ -1,0 +1,25 @@
+test_cases:
+  - test_case: user_transfer_money
+    steps:
+      - user: I want to transfer money
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: to John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: 150$
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "150"
+          - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/happy_path/user_transfer_money_mentioning_one_slot_upfront.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_transfer_money_mentioning_one_slot_upfront.yml
@@ -1,0 +1,42 @@
+test_cases:
+  - test_case: user transfers money mentioning one slot upfront
+    steps:
+      - user: I want to send some money to Jacqueline
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: Jacqueline
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: 130 dollars
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "130"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+
+  - test_case: user transfers money mentioning money slot upfront
+    steps:
+      - user: I want to send 50 dollars
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "50"
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/happy_path/user_transfer_money_mentioning_two_slots_upfront.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_transfer_money_mentioning_two_slots_upfront.yml
@@ -1,0 +1,34 @@
+test_cases:
+  - test_case: user_transfers_money_mentioning_two_slots_upfront
+    steps:
+      - user: I want to send 40 bucks to Ty
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "40"
+              - name: transfer_money_recipient
+                value: Ty
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - action_executed: execute_transfer
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+
+  - test_case: user transfers money mentioning two slots upfront eg 2
+    steps:
+      - user: I want to send 413$ to Maria
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "413"
+              - name: transfer_money_recipient
+                value: Maria
+          - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - action_executed: execute_transfer
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/happy_path/user_verifies_account.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_verifies_account.yml
@@ -1,0 +1,112 @@
+metadata:
+  - duplicate_answer_1:
+      turn_idx: 1
+  - duplicate_answer_2:
+      turn_idx: 2
+  - duplicate_answer_3:
+      turn_idx: 3
+
+test_cases:
+  - test_case: Verify account for non-California resident
+    steps:
+      - user: I want to verify my account
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: true
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: example@mail.com
+        assertions:
+          - slot_was_set:
+              - name: verify_account_email
+          - bot_uttered:
+              utter_name: utter_ask_based_in_california
+      - user: "no"
+        assertions:
+          - slot_was_set:
+              - name: based_in_california
+                value: false
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_confirmation
+      - user: "yes"
+        assertions:
+          - slot_was_set:
+              - name: verify_account_confirmation
+                value: true
+          - bot_uttered:
+              utter_name: utter_verify_account_success
+
+  - test_case: Verify account for California resident with insufficient income
+    steps:
+      - user: I want to verify my account
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: true
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: example@mail.com
+        assertions:
+          - slot_was_set:
+              - name: verify_account_email
+          - bot_uttered:
+              utter_name: utter_ask_based_in_california
+      - user: "yes"
+        assertions:
+          - slot_was_set:
+              - name: based_in_california
+                value: true
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_sufficient_california_income
+      - user: "no"
+        assertions:
+          - slot_was_set:
+              - name: verify_account_sufficient_california_income
+                value: false
+          - bot_uttered:
+              utter_name: utter_ca_income_insufficient
+          - bot_uttered:
+              utter_name: utter_can_do_something_else
+
+  - test_case: Verify account for California resident with sufficient income
+    steps:
+      - user: I want to verify my account
+        assertions:
+          - slot_was_set:
+              - name: route_session_to_calm
+                value: true
+          - bot_uttered:
+              utter_name: utter_ask_verify_account_email
+      - user: example@mail.com
+        assertions:
+            - slot_was_set:
+                - name: verify_account_email
+            - bot_uttered:
+                utter_name: utter_ask_based_in_california
+      - user: "yes"
+        metadata: duplicate_answer_1
+        assertions:
+            - slot_was_set:
+                - name: based_in_california
+                  value: true
+            - bot_uttered:
+                utter_name: utter_ask_verify_account_sufficient_california_income
+      - user: "yes"
+        metadata: duplicate_answer_2
+        assertions:
+            - slot_was_set:
+                - name: verify_account_sufficient_california_income
+                  value: true
+            - bot_uttered:
+                utter_name: utter_ask_verify_account_confirmation
+      - user: "yes"
+        metadata: duplicate_answer_3
+        assertions:
+          - slot_was_set:
+              - name: verify_account_confirmation
+                value: true
+          - bot_uttered:
+                utter_name: utter_verify_account_success
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/happy_path/user_wants_to_register_to_vote.yml
+++ b/e2e_tests_with_assertions/passing/happy_path/user_wants_to_register_to_vote.yml
@@ -1,0 +1,14 @@
+fixtures:
+  - california_resident:
+      - based_in_california: True
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user_wants_to_register_to_vote
+    fixtures:
+      - california_resident
+    steps:
+      - user: I want to register to vote
+        assertions:
+          - bot_uttered:
+              utter_name: utter_register_to_vote_in_california

--- a/e2e_tests_with_assertions/passing/invalid_path/check_portfolio_not_found.yml
+++ b/e2e_tests_with_assertions/passing/invalid_path/check_portfolio_not_found.yml
@@ -1,0 +1,41 @@
+test_cases:
+  - test_case: Authenticate and check portfolio with invalid value twice
+    steps:
+    - user: I want to check my portfolio
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_user_name
+    - user: Max
+      assertions:
+        - bot_uttered:
+            utter_name: utter_ask_user_password
+    - user: "1234"
+      assertions:
+        - bot_uttered:
+             utter_name: utter_authentication_successful
+        - bot_uttered:
+            utter_name: utter_ask_portfolio_type
+    - user: loan
+      assertions:
+        - bot_uttered:
+            utter_name: utter_categorical_slot_rejection
+        - bot_uttered:
+            utter_name: utter_ask_portfolio_type
+    - user: loan
+      assertions:
+        - bot_uttered:
+            utter_name: utter_categorical_slot_rejection
+        - bot_uttered:
+            utter_name: utter_ask_portfolio_type
+    - user: bonds
+      assertions:
+        - slot_was_set:
+            - name: portfolio_type
+              value: bonds
+            - name: portfolio_exists
+              value: True
+            - name: portfolio_options
+        - bot_uttered:
+            utter_name: utter_portfolio_options_found
+        - bot_uttered:
+            utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/invalid_path/user_asks_for_vacancies_no_department_entity_extracted.yml
+++ b/e2e_tests_with_assertions/passing/invalid_path/user_asks_for_vacancies_no_department_entity_extracted.yml
@@ -1,0 +1,18 @@
+test_cases:
+  - test_case: user_asks_for_vacancies_no_department_entity_extracted
+    # tests that pattern_cannot_handle is triggered when LLM tries to fill in a NLU slot.
+    steps:
+      - user: I would like to apply for a job at your establishment.
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_department
+      - user: I would like a role in the Supplies department.
+        assertion_order_enabled: true
+        assertions:
+          - flow_started: pattern_cannot_handle
+          - bot_uttered:
+              utter_name: utter_ask_rephrase
+          - flow_completed:
+              flow_id: pattern_cannot_handle
+          - bot_uttered:
+              utter_name: utter_ask_department

--- a/e2e_tests_with_assertions/passing/invalid_path/user_tries_to_set_up_recurrent_payment_with_invalid_values.yml
+++ b/e2e_tests_with_assertions/passing/invalid_path/user_tries_to_set_up_recurrent_payment_with_invalid_values.yml
@@ -1,0 +1,74 @@
+test_cases:
+  - test_case: user wants to set up a new recurrent payment and inserts an invalid frequency value
+    steps:
+      - user: I want to set up a new standing order payment.
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_type
+                value: standing order
+          - bot_uttered:
+              utter_name: utter_ask_recipient
+      - user: Jane Doe
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_recipient
+                value: Jane Doe
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_amount_of_money
+      - user: 20 pounds
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_amount_of_money
+                value: 20.0
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_frequency
+      - user: weekly
+        assertions:
+          - slot_was_not_set:
+              - name: recurrent_payment_frequency
+          - bot_uttered:
+              utter_name: utter_categorical_slot_rejection
+          - bot_uttered:
+              utter_name: utter_ask_recurrent_payment_frequency
+
+
+  - test_case: user wants to set up a new recurrent payment and gives an invalid start date (precedes current timestamp)
+    steps:
+      - user: i want to set up a new direct debit payment
+        assertions:
+          - slot_was_set:
+              - name: recurrent_payment_type
+                value: direct debit
+          - bot_uttered:
+              utter_name: utter_ask_recipient
+      - user: Jane Doe
+        assertions:
+            - slot_was_set:
+                - name: recurrent_payment_recipient
+                  value: Jane Doe
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_amount_of_money
+      - user: 20 pounds
+        assertions:
+            - slot_was_set:
+                - name: recurrent_payment_amount_of_money
+                  value: 20.0
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_frequency
+      - user: monthly
+        assertions:
+            - slot_was_set:
+                - name: recurrent_payment_frequency
+                  value: monthly
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_start_date
+      - user: 01/10/20
+        assertion_order_enabled: true
+        assertions:
+            - bot_uttered:
+                utter_name: utter_invalid_date
+            - slot_was_set:
+                - name: recurrent_payment_start_date
+                  value: null
+            - bot_uttered:
+                utter_name: utter_ask_recurrent_payment_start_date

--- a/e2e_tests_with_assertions/passing/invalid_user_inputs/user_sends_empty_message.yml
+++ b/e2e_tests_with_assertions/passing/invalid_user_inputs/user_sends_empty_message.yml
@@ -1,0 +1,8 @@
+# This requires a few changes in how empty user step messages are handled by the E2ETestRunner.
+#test_cases:
+#  - test_case: user sends empty message
+#    steps:
+#      - user: "     "
+#        assertions:
+#          - bot_uttered:
+#              utter_name: utter_user_input_empty_error_rasa

--- a/e2e_tests_with_assertions/passing/invalid_user_inputs/user_sends_long_message.yml
+++ b/e2e_tests_with_assertions/passing/invalid_user_inputs/user_sends_long_message.yml
@@ -1,0 +1,18 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user sends the long message that exceeds 420 characters
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: >- 
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sed diam eget sem ultrices dignissim. 
+          Suspendisse tincidunt varius feugiat. Quisque vitae leo facilisis, sagittis metus semper, mollis felis. Nulla 
+          eu ultrices quam. Praesent mattis nunc vitae libero laoreet commodo. Pellentesque habitant morbi tristique 
+          senectus et netus et malesuada fames ac turpis egestas. Nam nunc nisl, mollis id dolor nec, scelerisque 
+          lobortis tellus. Mauris consectetur quis nisi non viverra. Maecenas dapibus nam.
+        assertions:
+            - bot_uttered:
+                utter_name: utter_user_input_too_long_error_rasa

--- a/e2e_tests_with_assertions/passing/knowledge/knowledge_question_during_flow.yml
+++ b/e2e_tests_with_assertions/passing/knowledge/knowledge_question_during_flow.yml
@@ -1,0 +1,15 @@
+test_cases:
+  - test_case: user asks a knowledge question during flow
+    steps:
+      - user: I want to send some money to Tre
+      - utter: utter_ask_transfer_money_amount_of_money
+      - user: btw, are these transfers free of charge?
+      # - utter: utter_free_transfers
+        assertions:
+          - generative_response_is_grounded:
+              threshold: 0.85
+      - utter: utter_ask_transfer_money_amount_of_money
+      - user: great, 50$ then
+      - utter: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+      - utter: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/knowledge/user_follows_up_on_knowledge_question.yml
+++ b/e2e_tests_with_assertions/passing/knowledge/user_follows_up_on_knowledge_question.yml
@@ -1,0 +1,11 @@
+test_cases:
+  - test_case: user_follows_up_on_knowledge_question
+    steps:
+      - user: Are transfers on free with this service?
+        assertions:
+          - generative_response_is_grounded:
+              threshold: 0.90
+      - user: How about international ones?
+        assertions:
+          - generative_response_is_relevant:
+              threshold: 0.75

--- a/e2e_tests_with_assertions/passing/knowledge/user_starts_with_a_knowledge_question.yml
+++ b/e2e_tests_with_assertions/passing/knowledge/user_starts_with_a_knowledge_question.yml
@@ -1,0 +1,7 @@
+test_cases:
+  - test_case: user starts with a knowledge question
+    steps:
+      - user: Are transfers on free with this service?
+        assertions:
+          - generative_response_is_grounded:
+              threshold: 0.75

--- a/e2e_tests_with_assertions/passing/negations/users_says_they_dont_want_the_former_option.yml
+++ b/e2e_tests_with_assertions/passing/negations/users_says_they_dont_want_the_former_option.yml
@@ -1,0 +1,20 @@
+fixtures:
+  - route_to_calm:
+      - route_session_to_calm: True
+
+test_cases:
+  - test_case: user says they don't want the former option
+    fixtures:
+      - route_to_calm
+    steps:
+      - user: add
+        assertions:
+          - pattern_clarification_contains:
+              - 'add a card'
+              - 'add a contact'
+          - bot_uttered:
+              utter_name: utter_clarification_options_rasa
+      - user: not the former
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_add_contact_handle

--- a/e2e_tests_with_assertions/passing/negations/users_says_they_dont_want_the_former_option.yml
+++ b/e2e_tests_with_assertions/passing/negations/users_says_they_dont_want_the_former_option.yml
@@ -12,8 +12,6 @@ test_cases:
           - pattern_clarification_contains:
               - 'add a card'
               - 'add a contact'
-          - bot_uttered:
-              utter_name: utter_clarification_options_rasa
       - user: not the former
         assertions:
           - bot_uttered:

--- a/e2e_tests_with_assertions/passing/potential_bugs/user_asks_for_repition_of_previous_action.yml
+++ b/e2e_tests_with_assertions/passing/potential_bugs/user_asks_for_repition_of_previous_action.yml
@@ -1,0 +1,30 @@
+metadata:
+  - duplicate_msg_1:
+      turn_idx: 1
+  - duplicate_msg_2:
+      turn_idx: 2
+
+test_cases:
+  # this test makes sure that final confirmation is asked always
+  - test_case: user asks for repetition of previous action
+    steps:
+      - user: send 50 USD to John
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        metadata: duplicate_msg_1
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+          - bot_uttered:
+              utter_name: utter_can_do_something_else
+      - user: now do it again
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        metadata: duplicate_msg_2
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_and_then_cancels_the_flow_easy.yml
+++ b/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_and_then_cancels_the_flow_easy.yml
@@ -1,0 +1,19 @@
+test_cases:
+  - test_case: user tries to skip a question and then cancels the flow (easy)
+    steps:
+      - user: send money to John
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: skip this question
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: cancel
+        assertions:
+          - bot_uttered:
+              utter_name: utter_flow_cancelled_rasa
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_and_then_cancels_the_flow_medium.yml
+++ b/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_and_then_cancels_the_flow_medium.yml
@@ -1,0 +1,19 @@
+test_cases:
+  - test_case: user tries to skip a question and then cancels the flow (medium)
+    steps:
+      - user: send money to John
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: ask me something else
+        assertions:
+            - bot_uttered:
+                utter_name: utter_skip_question_answer
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: one moment, stop that
+        assertions:
+            - bot_uttered:
+                utter_name: utter_flow_cancelled_rasa
+            - bot_uttered:
+                utter_name: utter_can_do_something_else

--- a/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_multiple_times_medium.yml
+++ b/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_multiple_times_medium.yml
@@ -1,0 +1,33 @@
+test_cases:
+  - test_case: user tries to skip a question multiple times (easy)
+    steps:
+      - user: send money to John
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: ask me something else
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: proceed to the next one
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: i want to answer next question first
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: okay 50
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_once_easy.yml
+++ b/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_once_easy.yml
@@ -1,0 +1,21 @@
+test_cases:
+  - test_case: user tries to skip a question once (easy)
+    steps:
+      - user: send money to John
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: skip this question
+        assertions:
+          - bot_uttered:
+              utter_name: utter_skip_question_answer
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: okay 50
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_transfer_complete

--- a/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_once_medium.yml
+++ b/e2e_tests_with_assertions/passing/skip_question/user_tries_to_skip_a_question_once_medium.yml
@@ -1,0 +1,21 @@
+test_cases:
+  - test_case: user tries to skip a question once (medium)
+    steps:
+      - user: send money to John
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: ask me something else
+        assertions:
+            - bot_uttered:
+                utter_name: utter_skip_question_answer
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_amount_of_money
+      - user: okay 50
+        assertions:
+            - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+            - bot_uttered:
+                utter_name: utter_transfer_complete

--- a/e2e_tests_with_stub_custom_actions/passing/happy_path/user_adds_contact_to_their_list.yml
+++ b/e2e_tests_with_stub_custom_actions/passing/happy_path/user_adds_contact_to_their_list.yml
@@ -1,0 +1,37 @@
+stub_custom_actions:
+  add_contact:
+    events:
+      - event: slot
+        name: return_value
+        value: success
+    responses: []
+
+test_cases:
+  - test_case: user_adds_contact_to_their_list
+    steps:
+      - user: I want to add someone to my contact list
+        assertions:
+          - bot_uttered:
+                utter_name: utter_ask_add_contact_handle
+      - user: it's @barts
+        assertions:
+          - slot_was_set:
+                - name: add_contact_handle
+                  value: "@barts"
+          - bot_uttered:
+                utter_name: utter_ask_add_contact_name
+      - user: just Bart
+        assertions:
+          - slot_was_set:
+                - name: add_contact_name
+                  value: Bart
+          - bot_uttered:
+                utter_name: utter_ask_add_contact_confirmation
+      - user: yes
+        assertions:
+          - slot_was_set:
+                - name: add_contact_confirmation
+                  value: true
+          - action_executed: add_contact
+          - bot_uttered:
+                utter_name: utter_contact_added

--- a/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_balance.yml
+++ b/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_balance.yml
@@ -1,0 +1,17 @@
+stub_custom_actions:
+  check_balance:
+    events:
+      - event: slot
+        name: current_balance
+        value: 1200
+    responses: []
+
+test_cases:
+  - test_case: user_checks_balance
+    steps:
+      - user: Show my balance
+        assertions:
+          - bot_uttered:
+              text_matches: You still have 1200 in your account.
+          - bot_uttered:
+              utter_name: utter_can_do_something_else

--- a/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_balance_then_transactions.yml
+++ b/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_balance_then_transactions.yml
@@ -1,0 +1,27 @@
+stub_custom_actions:
+    check_balance:
+        events:
+        - event: slot
+          name: current_balance
+          value: 1300
+        responses: []
+    transaction_search:
+        events:
+        - event: slot
+          name: transactions_list
+          value: '{"amount": 500, "date": "2024-01-01", "description": "rent"}'
+        responses: []
+
+test_cases:
+  - test_case: user_checks_balance_then_transactions
+    steps:
+      - user: Show my balance
+        assertions:
+            - bot_uttered:
+                text_matches: You still have 1300 in your account.
+            - bot_uttered:
+                utter_name: utter_can_do_something_else
+      - user: Show my transactions please
+        assertions:
+            - bot_uttered:
+                text_matches: 'Your current transactions are:\n {"amount": 500, "date": "2024-01-01", "description": "rent"}'

--- a/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_portfolio.yml
+++ b/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_portfolio.yml
@@ -1,0 +1,47 @@
+stub_custom_actions:
+  action_authenticate_user:
+    events:
+      - event: slot
+        name: is_user_logged_in
+        value: true
+    responses: []
+  action_check_portfolio_exists:
+    events:
+      - event: slot
+        name: portfolio_exists
+        value: true
+    responses: []
+  action_show_portfolio:
+    events:
+      - event: slot
+        name: portfolio_options
+        value: 'mutual_funds'
+    responses: []
+
+test_cases:
+  - test_case: user_checks_portfolio
+    steps:
+      - user: I want to check my portfolio
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_name
+      - user: Max
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_user_password
+      - user: "1234"
+        assertions:
+          - bot_uttered:
+              utter_name: utter_authentication_successful
+          - bot_uttered:
+              utter_name: utter_ask_portfolio_type
+      - user: /SetSlots(portfolio_type=mutual_funds)
+        assertions:
+          - slot_was_set:
+              - name: portfolio_type
+                value: mutual_funds
+              - name: portfolio_exists
+                value: True
+              - name: portfolio_options
+          - bot_uttered:
+              utter_name: utter_portfolio_options_found

--- a/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_their_transactions.yml
+++ b/e2e_tests_with_stub_custom_actions/passing/happy_path/user_checks_their_transactions.yml
@@ -1,0 +1,16 @@
+stub_custom_actions:
+    transaction_search:
+        events:
+        - event: slot
+          name: transactions_list
+          value: '{"amount": 100, "date": "2024-01-01", "description": "restaurant"}'
+        responses: []
+
+
+test_cases:
+  - test_case: user_checks_their_transactions
+    steps:
+      - user: Show my transactions please
+        assertions:
+            - bot_uttered:
+                text_matches: 'Your current transactions are:\n {"amount": 100, "date": "2024-01-01", "description": "restaurant"}'

--- a/e2e_tests_with_stub_custom_actions/passing/happy_path/user_transfer_money.yml
+++ b/e2e_tests_with_stub_custom_actions/passing/happy_path/user_transfer_money.yml
@@ -1,0 +1,71 @@
+stub_custom_actions:
+  user_transfer_money_success::execute_transfer:
+    events:
+      - event: slot
+        name: "transfer_money_transfer_successful"
+        value: true
+    responses: []
+  user_transfer_money_failed::execute_transfer:
+    events:
+      - event: slot
+        name: "transfer_money_transfer_successful"
+        value: false
+    responses: []
+  check_transfer_funds:
+    events:
+      - event: slot
+        name: "transfer_money_has_sufficient_funds"
+        value: true
+
+test_cases:
+  - test_case: user_transfer_money_success
+    steps:
+      - user: I want to transfer money
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: to John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: 150$
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "150"
+          - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - action_executed: execute_transfer
+          - bot_uttered:
+              utter_name: utter_transfer_complete
+
+  - test_case: user_transfer_money_failed
+    steps:
+      - user: I want to transfer money
+        assertions:
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_recipient
+      - user: to John
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_recipient
+                value: John
+          - bot_uttered:
+              utter_name: utter_ask_transfer_money_amount_of_money
+      - user: 150$
+        assertions:
+          - slot_was_set:
+              - name: transfer_money_amount_of_money
+                value: "150"
+          - bot_uttered:
+                utter_name: utter_ask_transfer_money_final_confirmation
+      - user: "yes"
+        assertions:
+          - action_executed: execute_transfer
+          - bot_uttered:
+              utter_name: utter_transfer_failed

--- a/poetry.lock
+++ b/poetry.lock
@@ -5508,13 +5508,13 @@ fire = "*"
 
 [[package]]
 name = "rasa-pro"
-version = "3.10.0rc2"
+version = "3.10.0rc3"
 description = "State-of-the-art open-core Conversational AI framework for Enterprises that natively leverages generative AI for effortless assistant development."
 optional = false
 python-versions = ">=3.8.1,<3.11"
 files = [
-    {file = "rasa_pro-3.10.0rc2-py3-none-any.whl", hash = "sha256:3b62c87ac08a7f40a742e63ef7dabd1455c06b3757d74dd47329b9381daadd85"},
-    {file = "rasa_pro-3.10.0rc2.tar.gz", hash = "sha256:b3e83207c5f3fe6c40741168376d48687003550f469d293c2265f66c6c82cabf"},
+    {file = "rasa_pro-3.10.0rc3-py3-none-any.whl", hash = "sha256:72c2b864ee298ca123d214c2d965206e10b6cab6f4fc82ad9b7c663b46e4a445"},
+    {file = "rasa_pro-3.10.0rc3.tar.gz", hash = "sha256:0cb87ccfd2ae9f4c116932c10a8011d2251fca874e996232fa0795f27d548c60"},
 ]
 
 [package.dependencies]
@@ -8159,4 +8159,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "48dec83b524cc7d32e6c213ea1f484785d401a4b6c496a16885fb6cc69b51a7f"
+content-hash = "7e08d644d945d7a1eac818725cabfe85418214693a6c6b5b72ae3e8a46ac4f8c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2605,36 +2605,6 @@ files = [
 ]
 
 [[package]]
-name = "jax"
-version = "0.4.13"
-description = "Differentiate, compile, and transform Numpy code."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "jax-0.4.13.tar.gz", hash = "sha256:03bfe6749dfe647f16f15f6616638adae6c4a7ca7167c75c21961ecfd3a3baaa"},
-]
-
-[package.dependencies]
-importlib_metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
-ml_dtypes = ">=0.1.0"
-numpy = ">=1.21"
-opt_einsum = "*"
-scipy = ">=1.7"
-
-[package.extras]
-australis = ["protobuf (>=3.13,<4)"]
-ci = ["jaxlib (==0.4.12)"]
-cpu = ["jaxlib (==0.4.13)"]
-cuda = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
-cuda11-cudnn86 = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
-cuda11-local = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
-cuda11-pip = ["jaxlib (==0.4.13+cuda11.cudnn86)", "nvidia-cublas-cu11 (>=11.11)", "nvidia-cuda-cupti-cu11 (>=11.8)", "nvidia-cuda-nvcc-cu11 (>=11.8)", "nvidia-cuda-runtime-cu11 (>=11.8)", "nvidia-cudnn-cu11 (>=8.8)", "nvidia-cufft-cu11 (>=10.9)", "nvidia-cusolver-cu11 (>=11.4)", "nvidia-cusparse-cu11 (>=11.7)"]
-cuda12-local = ["jaxlib (==0.4.13+cuda12.cudnn89)"]
-cuda12-pip = ["jaxlib (==0.4.13+cuda12.cudnn89)", "nvidia-cublas-cu12", "nvidia-cuda-cupti-cu12", "nvidia-cuda-nvcc-cu12", "nvidia-cuda-runtime-cu12", "nvidia-cudnn-cu12 (>=8.9)", "nvidia-cufft-cu12", "nvidia-cusolver-cu12", "nvidia-cusparse-cu12"]
-minimum-jaxlib = ["jaxlib (==0.4.11)"]
-tpu = ["jaxlib (==0.4.13)", "libtpu-nightly (==0.1.dev20230622)"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.4"
 description = "A very fast and expressive template engine."
@@ -2839,12 +2809,13 @@ typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "keras"
-version = "2.12.0"
+version = "2.13.1"
 description = "Deep learning for humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "keras-2.12.0-py2.py3-none-any.whl", hash = "sha256:35c39534011e909645fb93515452e98e1a0ce23727b55d4918b9c58b2308c15e"},
+    {file = "keras-2.13.1-py3-none-any.whl", hash = "sha256:5ce5f706f779fa7330e63632f327b75ce38144a120376b2ae1917c00fa6136af"},
+    {file = "keras-2.13.1.tar.gz", hash = "sha256:5df12cc241a015a11b65ddb452c0eeb2744fce21d9b54ba48db87492568ccc68"},
 ]
 
 [[package]]
@@ -3512,41 +3483,6 @@ certifi = "*"
 pycryptodome = "*"
 typing-extensions = "*"
 urllib3 = "*"
-
-[[package]]
-name = "ml-dtypes"
-version = "0.2.0"
-description = ""
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "ml_dtypes-0.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df6a76e1c8adf484feb138ed323f9f40a7b6c21788f120f7c78bec20ac37ee81"},
-    {file = "ml_dtypes-0.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc29a0524ef5e23a7fbb8d881bdecabeb3fc1d19d9db61785d077a86cb94fab2"},
-    {file = "ml_dtypes-0.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08c391c2794f2aad358e6f4c70785a9a7b1df980ef4c232b3ccd4f6fe39f719"},
-    {file = "ml_dtypes-0.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:75015818a7fccf99a5e8ed18720cb430f3e71a8838388840f4cdf225c036c983"},
-    {file = "ml_dtypes-0.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e70047ec2c83eaee01afdfdabee2c5b0c133804d90d0f7db4dd903360fcc537c"},
-    {file = "ml_dtypes-0.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36d28b8861a8931695e5a31176cad5ae85f6504906650dea5598fbec06c94606"},
-    {file = "ml_dtypes-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e85ba8e24cf48d456e564688e981cf379d4c8e644db0a2f719b78de281bac2ca"},
-    {file = "ml_dtypes-0.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:832a019a1b6db5c4422032ca9940a990fa104eee420f643713241b3a518977fa"},
-    {file = "ml_dtypes-0.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8faaf0897942c8253dd126662776ba45f0a5861968cf0f06d6d465f8a7bc298a"},
-    {file = "ml_dtypes-0.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35b984cddbe8173b545a0e3334fe56ea1a5c3eb67c507f60d0cfde1d3fa8f8c2"},
-    {file = "ml_dtypes-0.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:022d5a4ee6be14569c2a9d1549e16f1ec87ca949681d0dca59995445d5fcdd5b"},
-    {file = "ml_dtypes-0.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:50845af3e9a601810751b55091dee6c2562403fa1cb4e0123675cf3a4fc2c17a"},
-    {file = "ml_dtypes-0.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f00c71c8c63e03aff313bc6a7aeaac9a4f1483a921a6ffefa6d4404efd1af3d0"},
-    {file = "ml_dtypes-0.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80d304c836d73f10605c58ccf7789c171cc229bfb678748adfb7cea2510dfd0e"},
-    {file = "ml_dtypes-0.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32107e7fa9f62db9a5281de923861325211dfff87bd23faefb27b303314635ab"},
-    {file = "ml_dtypes-0.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:1749b60348da71fd3c2ab303fdbc1965958dc50775ead41f5669c932a341cafd"},
-    {file = "ml_dtypes-0.2.0.tar.gz", hash = "sha256:6488eb642acaaf08d8020f6de0a38acee7ac324c1e6e92ee0c0fea42422cb797"},
-]
-
-[package.dependencies]
-numpy = [
-    {version = ">1.20", markers = "python_version <= \"3.9\""},
-    {version = ">=1.21.2", markers = "python_version > \"3.9\""},
-]
-
-[package.extras]
-dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
 
 [[package]]
 name = "mlflow"
@@ -5508,13 +5444,13 @@ fire = "*"
 
 [[package]]
 name = "rasa-pro"
-version = "3.10.0rc3"
+version = "3.10.0"
 description = "State-of-the-art open-core Conversational AI framework for Enterprises that natively leverages generative AI for effortless assistant development."
 optional = false
 python-versions = ">=3.8.1,<3.11"
 files = [
-    {file = "rasa_pro-3.10.0rc3-py3-none-any.whl", hash = "sha256:72c2b864ee298ca123d214c2d965206e10b6cab6f4fc82ad9b7c663b46e4a445"},
-    {file = "rasa_pro-3.10.0rc3.tar.gz", hash = "sha256:0cb87ccfd2ae9f4c116932c10a8011d2251fca874e996232fa0795f27d548c60"},
+    {file = "rasa_pro-3.10.0-py3-none-any.whl", hash = "sha256:206262ce346392609643af9a17b2fdd259206483a0847ec4b4f38fb89e8eb4ea"},
+    {file = "rasa_pro-3.10.0.tar.gz", hash = "sha256:0b1ead8911212de002c5e87f7897b974cd2bef7896d1da5ddddf28db6635a47a"},
 ]
 
 [package.dependencies]
@@ -5552,6 +5488,7 @@ joblib = ">=1.2.0,<1.3.0"
 jsonpatch = ">=1.33,<2.0"
 jsonpickle = ">=3.0,<3.1"
 jsonschema = ">=4.22"
+keras = "2.13.1"
 langchain = ">=0.2.0,<0.3.0"
 langchain-community = ">=0.2.0,<0.3.0"
 litellm = ">=1.44.7,<1.45.0"
@@ -5594,7 +5531,7 @@ pyyaml = ">=6.0"
 qdrant-client = ">=1.9.0,<2.0.0"
 questionary = ">=1.10.0,<2.1.0"
 randomname = ">=0.2.1,<0.3.0"
-rasa-sdk = "3.10.0rc2"
+rasa-sdk = "3.10.0"
 redis = ">=4.6.0,<6.0"
 regex = ">=2022.10.31,<2022.11"
 requests = ">=2.31.0,<2.32.0"
@@ -5616,16 +5553,16 @@ structlog = ">=23.1.0,<23.2.0"
 structlog-sentry = ">=2.0.3,<3.0.0"
 tarsafe = ">=0.0.5,<0.0.6"
 tenacity = ">=8.4.1,<8.5.0"
-tensorflow = {version = "2.12.0", markers = "sys_platform != \"darwin\" or platform_machine != \"arm64\""}
-tensorflow-cpu-aws = {version = "2.12.0", markers = "sys_platform == \"linux\" and (platform_machine == \"arm64\" or platform_machine == \"aarch64\")"}
+tensorflow = {version = "2.13.0rc0", markers = "sys_platform != \"darwin\" or platform_machine != \"arm64\""}
+tensorflow-cpu-aws = {version = "2.13.0rc0", markers = "sys_platform == \"linux\" and (platform_machine == \"arm64\" or platform_machine == \"aarch64\")"}
 tensorflow_hub = ">=0.13.0,<0.14.0"
-tensorflow-intel = {version = "2.12.0", markers = "sys_platform == \"win32\""}
+tensorflow-intel = {version = "2.13.0rc0", markers = "sys_platform == \"win32\""}
 tensorflow-io-gcs-filesystem = [
     {version = "0.31", markers = "sys_platform == \"win32\""},
     {version = "0.32", markers = "sys_platform == \"darwin\" and platform_machine != \"arm64\" or sys_platform == \"linux\""},
 ]
-tensorflow-macos = {version = "2.12.0", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
-tensorflow-text = {version = "2.12.0", markers = "sys_platform != \"win32\" and (platform_machine != \"arm64\" and platform_machine != \"aarch64\")"}
+tensorflow-macos = {version = "2.13.0rc0", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
+tensorflow-text = {version = "2.13.0rc0", markers = "sys_platform != \"win32\" and (platform_machine != \"arm64\" and platform_machine != \"aarch64\")"}
 terminaltables = ">=3.1.10,<3.2.0"
 tiktoken = ">=0.7.0,<0.8.0"
 tqdm = ">=4.66.2,<5.0.0"
@@ -5654,13 +5591,13 @@ reference = "rasa-pro"
 
 [[package]]
 name = "rasa-sdk"
-version = "3.10.0rc2"
+version = "3.10.0"
 description = "Open source machine learning framework to automate text- and voice-based conversations: NLU, dialogue management, connect to Slack, Facebook, and more - Create chatbots and voice assistants"
 optional = false
 python-versions = "<3.11,>=3.8"
 files = [
-    {file = "rasa_sdk-3.10.0rc2-py3-none-any.whl", hash = "sha256:8d8ed44cd61c05fe374c95737c19e06f13502c5c9ce6dcb738da55399c3bd04a"},
-    {file = "rasa_sdk-3.10.0rc2.tar.gz", hash = "sha256:7465a2a996d1761e064044f50a76488a2ffce7a8fcac180dd90dc23d8ccda6a4"},
+    {file = "rasa_sdk-3.10.0-py3-none-any.whl", hash = "sha256:134889d1d9c25daaa65ec6cc2f4883319a6fd87b506820fae3a62a6f859d7143"},
+    {file = "rasa_sdk-3.10.0.tar.gz", hash = "sha256:bd541b3d4c2bba46a3a816285ba4ea94c18f08e6bec6deb16c4485650e0c00a9"},
 ]
 
 [package.dependencies]
@@ -6785,12 +6722,12 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
 name = "tensorboard"
-version = "2.12.3"
+version = "2.13.0"
 description = "TensorBoard lets you watch Tensors Flow"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tensorboard-2.12.3-py3-none-any.whl", hash = "sha256:b4a69366784bc347e02fbe7d847e01896a649ca52f8948a11005e205dcf724fb"},
+    {file = "tensorboard-2.13.0-py3-none-any.whl", hash = "sha256:ab69961ebddbddc83f5fa2ff9233572bdad5b883778c35e4fe94bf1798bd8481"},
 ]
 
 [package.dependencies]
@@ -6821,48 +6758,51 @@ files = [
 
 [[package]]
 name = "tensorflow"
-version = "2.12.0"
+version = "2.13.0rc0"
 description = "TensorFlow is an open source machine learning framework for everyone."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tensorflow-2.12.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:be4ac0dfcc7a16f6df2bc19bd322e312235ab3f7b0c7297f96c92c44bb14d2a1"},
-    {file = "tensorflow-2.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5193ddb3bb5120cb445279beb08ed9e74a85a4eeb2485550d6fb707a89d9a88"},
-    {file = "tensorflow-2.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:357d9d2851188a8d27ee195345b4d175cad970150d1344ba9d9fcc4bf2b68336"},
-    {file = "tensorflow-2.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:c8001210df7202ef6267150865b0b79f834c3ca69ee3132277de8eeb994dffde"},
-    {file = "tensorflow-2.12.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:91dccda42c03569d8c787190482a11ecae3b9b173aaa9166f0ab20cecc9c31f4"},
-    {file = "tensorflow-2.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31f81eb8adaeb558963f5d8b47dbfcc398d898f0857bf3de6b6484350236b7b5"},
-    {file = "tensorflow-2.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ec4a2934ea19e92f27a9668ece43025ed5efe14b5d19be53b07692bc8a4189d"},
-    {file = "tensorflow-2.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e7641e2a6e32f31ff233495478a9cc86b7c038140eab714a61eeddbbbb327c3"},
-    {file = "tensorflow-2.12.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:a7194e744c5a7f3e759ecb949527b4a07718a6d1110e6e82fd4ce0c5586a7d4a"},
-    {file = "tensorflow-2.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4afc2dd57435f29ebe249eb5f595d89b0e73be94922eeb7110aa6280a332837c"},
-    {file = "tensorflow-2.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23850332f1f9f778d697c9dba63ca52be72cb73363e75ad358f07ddafef63c01"},
-    {file = "tensorflow-2.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:e29fcf6cfd069aefb4b44f357cccbb4415a5a3d7b5b516eaf4450062fe40021e"},
-    {file = "tensorflow-2.12.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:42fc2635e9420faee781a16bd393126f29cd39aa2b9d02901f24d8497bd6f958"},
-    {file = "tensorflow-2.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76414355e420edb9154b4e72113eef5813ccb71701fda959afbbc1eebe3099bd"},
-    {file = "tensorflow-2.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:020d6a54cb26020bdc71a7bae8ee35be05096f63e773dc517f6e87c49de62c50"},
-    {file = "tensorflow-2.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:9f70a8f9ab46e5ed436850aa60d1cd40645f5c669e14bcad48915dc1f597dda2"},
+    {file = "tensorflow-2.13.0rc0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:1c99a65b120747c511ea0945c6cf6d83dd74e63c92e8898d0e07c3befe00f6f2"},
+    {file = "tensorflow-2.13.0rc0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:3818a57638e21149e0b827ad0c7db2facfd21a8d71068038ec02071a0fe571f8"},
+    {file = "tensorflow-2.13.0rc0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c49fb147a5c8fdf7dc11df94fc3498e749e32b990f336e14777fae41dad34e6c"},
+    {file = "tensorflow-2.13.0rc0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24f0ffb2e95da565a9132f9a9bd8d0c400d54de0a70165a3a8a7fba3a9f2304e"},
+    {file = "tensorflow-2.13.0rc0-cp310-cp310-win_amd64.whl", hash = "sha256:149184a24f8646f0ab78b2b24a0aecb8538769e515358ea7139709e6bcef9171"},
+    {file = "tensorflow-2.13.0rc0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:2c32bd4ccb9f2c0b81489fb2d664bfaa06eb8a2fb4d0647694cd8078505276c0"},
+    {file = "tensorflow-2.13.0rc0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:567eed51f20c769dd123ee1c85ff0962f77e52414fc0cd85e8dd446f4ab1d529"},
+    {file = "tensorflow-2.13.0rc0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b873e52f67d61226106a74c2fe70b16e21caf868ec597b37759c77b517e04a0"},
+    {file = "tensorflow-2.13.0rc0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffb8d18c06ed7d91a4d312ac1824ffa91ef38577eae27f8e1bd139019777ea8f"},
+    {file = "tensorflow-2.13.0rc0-cp311-cp311-win_amd64.whl", hash = "sha256:5f4a4e3372c22bc957f3c51ccd1a11f2dfe8ce63d7970dd9ace909aa007a45a3"},
+    {file = "tensorflow-2.13.0rc0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:01d987c55f2472595e351a1ff467be99836d51aed0621db0d28f0b0a7813ca1a"},
+    {file = "tensorflow-2.13.0rc0-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:189134fe744692f92b547f4a4a9f1e254fcc0623bf082f4510dfda5eb966bfb9"},
+    {file = "tensorflow-2.13.0rc0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d790fd74639a611b0b2284bccd0cdb331cb41621c980b14fbf0a22451b75f5a"},
+    {file = "tensorflow-2.13.0rc0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e26443a066c964ea8c8fc3bd262974ccdd612541f4738ab4be08be855abd274c"},
+    {file = "tensorflow-2.13.0rc0-cp38-cp38-win_amd64.whl", hash = "sha256:498e786ee3f50ca4599a4cf2adbe517c78df26081fda6198e73165cb5ab804f5"},
+    {file = "tensorflow-2.13.0rc0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:8cb7063cba29253290e17933c8439e9a15195d837ed53378849b5eaed978de8b"},
+    {file = "tensorflow-2.13.0rc0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:897c37b2ffac1dca6b1c88cf66c5941ef0ad29deaa8bb75e9310c35738624f9d"},
+    {file = "tensorflow-2.13.0rc0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bf1ec1f2008560487577b8dfb95fe2a601b719a7ba1e6a6cc6c9b3858e5c528"},
+    {file = "tensorflow-2.13.0rc0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:190fadd1e8e48ab6bc12c88fccd7029109ea9d0f0ea46a0b5747c2319a03745c"},
+    {file = "tensorflow-2.13.0rc0-cp39-cp39-win_amd64.whl", hash = "sha256:584b2448d9895e84f88761d630a07bdd38c35ad00cab4fe6e9e8cfe027c4a7c2"},
 ]
 
 [package.dependencies]
 absl-py = ">=1.0.0"
 astunparse = ">=1.6.0"
-flatbuffers = ">=2.0"
+flatbuffers = ">=23.1.21"
 gast = ">=0.2.1,<=0.4.0"
 google-pasta = ">=0.1.1"
 grpcio = ">=1.24.3,<2.0"
 h5py = ">=2.9.0"
-jax = ">=0.3.15"
-keras = ">=2.12.0,<2.13"
+keras = ">=2.13.1rc0,<2.14"
 libclang = ">=13.0.0"
-numpy = ">=1.22,<1.24"
+numpy = ">=1.22"
 opt-einsum = ">=2.3.2"
 packaging = "*"
 protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 setuptools = "*"
 six = ">=1.12.0"
-tensorboard = ">=2.12,<2.13"
-tensorflow-estimator = ">=2.12.0,<2.13"
+tensorboard = ">=2.13,<2.14"
+tensorflow-estimator = ">=2.13.0rc0,<2.14"
 tensorflow-io-gcs-filesystem = {version = ">=0.23.1", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
 termcolor = ">=1.1.0"
 typing-extensions = ">=3.6.6"
@@ -6870,36 +6810,35 @@ wrapt = ">=1.11.0,<1.15"
 
 [[package]]
 name = "tensorflow-cpu-aws"
-version = "2.12.0"
+version = "2.13.0rc0"
 description = "TensorFlow is an open source machine learning framework for everyone."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tensorflow_cpu_aws-2.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3d5f0cb1bdec07157220f95620af0a25b170273cec9a9b26b3f51229220b965"},
-    {file = "tensorflow_cpu_aws-2.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92cc4ff90710a2dfa901994503a65545a75ea7a7ffe830344c201d4a5eee1190"},
-    {file = "tensorflow_cpu_aws-2.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b527847d00ec39e10cd3f92fc925cf89ae51944edcba46eea26bb6af276ff35"},
-    {file = "tensorflow_cpu_aws-2.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3eb8c4d34161cb2af4adebdb71edb25a390d4610c5254e39ac5a790eff2c7ba8"},
+    {file = "tensorflow_cpu_aws-2.13.0rc0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:195b636d6b56649e23c4975f6a4b648e756bc9bbb153e666af3f8bacdae3a93f"},
+    {file = "tensorflow_cpu_aws-2.13.0rc0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0c1a03a5f67fc7402edcbce2895b3421494cf7aea2ae2b1b3256df52a715cae"},
+    {file = "tensorflow_cpu_aws-2.13.0rc0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ac6994a0d01962a9665b420c2cbde7d25b9bf6b0dd1c2d732b0c46e1aa3edf5"},
+    {file = "tensorflow_cpu_aws-2.13.0rc0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d37fd1829639aa39cfe0bc4be97d65b4e3fb58f7a135a7456ec95b2b2b7b7def"},
 ]
 
 [package.dependencies]
 absl-py = ">=1.0.0"
 astunparse = ">=1.6.0"
-flatbuffers = ">=2.0"
+flatbuffers = ">=23.1.21"
 gast = ">=0.2.1,<=0.4.0"
 google-pasta = ">=0.1.1"
 grpcio = ">=1.24.3,<2.0"
 h5py = ">=2.9.0"
-jax = ">=0.3.15"
-keras = ">=2.12.0,<2.13"
+keras = ">=2.13.1rc0,<2.14"
 libclang = ">=13.0.0"
-numpy = ">=1.22,<1.24"
+numpy = ">=1.22"
 opt-einsum = ">=2.3.2"
 packaging = "*"
 protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 setuptools = "*"
 six = ">=1.12.0"
-tensorboard = ">=2.12,<2.13"
-tensorflow-estimator = ">=2.12.0,<2.13"
+tensorboard = ">=2.13,<2.14"
+tensorflow-estimator = ">=2.13.0rc0,<2.14"
 tensorflow-io-gcs-filesystem = {version = ">=0.23.1", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
 termcolor = ">=1.1.0"
 typing-extensions = ">=3.6.6"
@@ -6907,12 +6846,12 @@ wrapt = ">=1.11.0,<1.15"
 
 [[package]]
 name = "tensorflow-estimator"
-version = "2.12.0"
+version = "2.13.0"
 description = "TensorFlow Estimator."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tensorflow_estimator-2.12.0-py2.py3-none-any.whl", hash = "sha256:59b191bead4883822de3d63ac02ace11a83bfe6c10d64d0c4dfde75a50e60ca1"},
+    {file = "tensorflow_estimator-2.13.0-py2.py3-none-any.whl", hash = "sha256:6f868284eaa654ae3aa7cacdbef2175d0909df9fcf11374f5166f8bf475952aa"},
 ]
 
 [[package]]
@@ -6935,36 +6874,35 @@ make-nearest-neighbour-index = ["annoy", "apache-beam"]
 
 [[package]]
 name = "tensorflow-intel"
-version = "2.12.0"
+version = "2.13.0rc0"
 description = "TensorFlow is an open source machine learning framework for everyone."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tensorflow_intel-2.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:816a6b9018d1ae0defe94508aab2512228fb6a54ab51f5f4f025c857cfe5c7e5"},
-    {file = "tensorflow_intel-2.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:2789b97028ffbfa64846a1736da0021b7be22567d2cdfff826583e63c6d21485"},
-    {file = "tensorflow_intel-2.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:a1eaab8edc87207c9510799aada88c55019055095ae0de0fea0f21a13fae4424"},
-    {file = "tensorflow_intel-2.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:2c3ece439d589362374d6e9f7775d2fac4591e0d9fc22a431f2eeaa4a0d2994a"},
+    {file = "tensorflow_intel-2.13.0rc0-cp310-cp310-win_amd64.whl", hash = "sha256:c9a0e53a0da98201048f55b72068b25c0f17af38b28f57c3355e7e90842f1ccc"},
+    {file = "tensorflow_intel-2.13.0rc0-cp311-cp311-win_amd64.whl", hash = "sha256:04b26c5648c5ccea704a28d563c49a17919b87a935519ff292b423fbfc193474"},
+    {file = "tensorflow_intel-2.13.0rc0-cp38-cp38-win_amd64.whl", hash = "sha256:f4b16c75a063a745a76a3068e7bf1cb361d7dcae07985cb27b5d0e4e69207f0e"},
+    {file = "tensorflow_intel-2.13.0rc0-cp39-cp39-win_amd64.whl", hash = "sha256:3f9d15c3dc2b4d75c35a07df21c1be42118e63bf414bf49b756d7488f31187a8"},
 ]
 
 [package.dependencies]
 absl-py = ">=1.0.0"
 astunparse = ">=1.6.0"
-flatbuffers = ">=2.0"
+flatbuffers = ">=23.1.21"
 gast = ">=0.2.1,<=0.4.0"
 google-pasta = ">=0.1.1"
 grpcio = ">=1.24.3,<2.0"
 h5py = ">=2.9.0"
-jax = ">=0.3.15"
-keras = ">=2.12.0,<2.13"
+keras = ">=2.13.1rc0,<2.14"
 libclang = ">=13.0.0"
-numpy = ">=1.22,<1.24"
+numpy = ">=1.22"
 opt-einsum = ">=2.3.2"
 packaging = "*"
 protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 setuptools = "*"
 six = ">=1.12.0"
-tensorboard = ">=2.12,<2.13"
-tensorflow-estimator = ">=2.12.0,<2.13"
+tensorboard = ">=2.13,<2.14"
+tensorflow-estimator = ">=2.13.0rc0,<2.14"
 tensorflow-io-gcs-filesystem = {version = ">=0.23.1", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
 termcolor = ">=1.1.0"
 typing-extensions = ">=3.6.6"
@@ -7069,40 +7007,35 @@ tensorflow-rocm = ["tensorflow-rocm (>=2.16.0,<2.17.0)"]
 
 [[package]]
 name = "tensorflow-macos"
-version = "2.12.0"
+version = "2.13.0rc0"
 description = "TensorFlow is an open source machine learning framework for everyone."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tensorflow_macos-2.12.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:db464c88e10e927725997f9b872a21c9d057789d3b7e9a26e4ef1af41d0bcc8c"},
-    {file = "tensorflow_macos-2.12.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:172277c33cb1ae0da19f98c5bcd4946149cfa73c8ea05c6ba18365d58dd3c6f2"},
-    {file = "tensorflow_macos-2.12.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:9c9b14fbb73ec4cb0f209722a1489020fd8614c92ae22589f2309c48cefdf21f"},
-    {file = "tensorflow_macos-2.12.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:6a54539bd076746f69ae8bef7282f981674fe4dbf59c3a84c4af86ae6bae9d5c"},
-    {file = "tensorflow_macos-2.12.0-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:e3fa53e63672fd71998bbd71cc5478c74dbe5a2d9291d1801c575358c28403c2"},
-    {file = "tensorflow_macos-2.12.0-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:5499312c21ed3ed47cc6b4cf861896e9564c2c32d8d3c2ef1437c5ca31adfc73"},
-    {file = "tensorflow_macos-2.12.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:84cb873c90be63efabfecca53fdc48b734a037d0750532b55cb7ce7c343b5cac"},
-    {file = "tensorflow_macos-2.12.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:85d9451a691324490e1d644b1051972e14edc249004eef5831b3510df9e36515"},
+    {file = "tensorflow_macos-2.13.0rc0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:4720028e919a67746e0c01b1ea397ee0c09f98f4a3a106783a822385df2e5bd8"},
+    {file = "tensorflow_macos-2.13.0rc0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:86fc993297dee74f400eac5325ad1bd39cf4aaeae7920cb0756f5c90dc38fe95"},
+    {file = "tensorflow_macos-2.13.0rc0-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:d366ed9add100fb8a7111e4a5bb45b71f9bcf67899f41b7c9156dd587a4842b1"},
+    {file = "tensorflow_macos-2.13.0rc0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:2204163c71b76a20b17d05dbfe2d74183660c0312741c6b831bd7cf254879765"},
 ]
 
 [package.dependencies]
 absl-py = ">=1.0.0"
 astunparse = ">=1.6.0"
-flatbuffers = ">=2.0"
+flatbuffers = ">=23.1.21"
 gast = ">=0.2.1,<=0.4.0"
 google-pasta = ">=0.1.1"
 grpcio = ">=1.24.3,<2.0"
 h5py = ">=2.9.0"
-jax = ">=0.3.15"
-keras = ">=2.12.0,<2.13"
+keras = ">=2.13.1rc0,<2.14"
 libclang = ">=13.0.0"
-numpy = ">=1.22,<1.24"
+numpy = ">=1.22"
 opt-einsum = ">=2.3.2"
 packaging = "*"
 protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 setuptools = "*"
 six = ">=1.12.0"
-tensorboard = ">=2.12,<2.13"
-tensorflow-estimator = ">=2.12.0,<2.13"
+tensorboard = ">=2.13,<2.14"
+tensorflow-estimator = ">=2.13.0rc0,<2.14"
 tensorflow-io-gcs-filesystem = {version = ">=0.23.1", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
 termcolor = ">=1.1.0"
 typing-extensions = ">=3.6.6"
@@ -7110,23 +7043,23 @@ wrapt = ">=1.11.0,<1.15"
 
 [[package]]
 name = "tensorflow-text"
-version = "2.12.0"
+version = "2.13.0rc0"
 description = "TF.Text is a TensorFlow library of text related ops, modules, and subgraphs."
 optional = false
 python-versions = "*"
 files = [
-    {file = "tensorflow_text-2.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6eedfb6a57c2b7dd320aa2b1dd3662c85de3c62fa74cec17a619836ae38e823a"},
-    {file = "tensorflow_text-2.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a101244702c1a618ab29d1e034ccadccd290538670f08b3a845d8160a313fd39"},
-    {file = "tensorflow_text-2.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f88a3f57b0ba2561d979038420d12ac1d3892a0c89f9918df686fe041afec61c"},
-    {file = "tensorflow_text-2.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ac0e01501165e2eaf70d90c054069ac74c24f311ac576c616ef925408918904"},
-    {file = "tensorflow_text-2.12.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c7444166a76b993c0918909e7c4378c61148a079f347a3fba8017f6b820a8fcf"},
-    {file = "tensorflow_text-2.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e029bdbfe3678054463a58a5d76e9d7f78052848369f32316ba1bd5e6fd632a"},
-    {file = "tensorflow_text-2.12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1562c3ae0893402ca5175c3c6002a4d6cbac6fbce4eee6c7798a30c12d0ffcc0"},
-    {file = "tensorflow_text-2.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:332a65951576c174183df2c25df4e9a8a34e254cc5862fd8c27401eb17658bb3"},
+    {file = "tensorflow_text-2.13.0rc0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ebe45d58b5e34535e5818ada9699d74c5fff0630c80e6f9539555ddd321c0ceb"},
+    {file = "tensorflow_text-2.13.0rc0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2af7031654103ab4c8e89bc47375f5b2169d8085724af16d6a011b1592f022b5"},
+    {file = "tensorflow_text-2.13.0rc0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:443bdc97427f89f1092948a46f17fd3376203d5b5452371776a474dfcfaa1c5e"},
+    {file = "tensorflow_text-2.13.0rc0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:405c0e3fdbbe78b7dc26fa3c4ecbf7c89b95b9b3dec5a09ea00a81742dfdba53"},
+    {file = "tensorflow_text-2.13.0rc0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f8c46b86f8233b31727415efeb60396582f962adc49e7bdeaf56b9aaa6c58045"},
+    {file = "tensorflow_text-2.13.0rc0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b97f9039e9166b00c481ae42eada7f7a583647864d016a8e85f1a0255c55e1e0"},
+    {file = "tensorflow_text-2.13.0rc0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:36f783227d911e530668d5e491653b3668dbc295ab5bf59f196f80090a0d04f5"},
+    {file = "tensorflow_text-2.13.0rc0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ae82a08ef20976bc7ad723e127f9d3b8c6692209e437f9f9a3fcef9532403ed"},
 ]
 
 [package.dependencies]
-tensorflow = {version = ">=2.12.0,<2.13", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
+tensorflow = {version = ">=2.13.0rc0,<2.14", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
 tensorflow-hub = ">=0.8.0"
 
 [package.extras]
@@ -8159,4 +8092,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "7e08d644d945d7a1eac818725cabfe85418214693a6c6b5b72ae3e8a46ac4f8c"
+content-hash = "eadc7fd58b54b314489527296f6cd42a39b598c5cf19f22ffa7beba153c1caa2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3072,6 +3072,7 @@ description = "Clang Python Bindings, mirrored from the official LLVM repo: http
 optional = false
 python-versions = "*"
 files = [
+    {file = "libclang-18.1.1-1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a"},
     {file = "libclang-18.1.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6f14c3f194704e5d09769108f03185fce7acaf1d1ae4bbb2f30a72c2400cb7c5"},
     {file = "libclang-18.1.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:83ce5045d101b669ac38e6da8e58765f12da2d3aafb3b9b98d88b286a60964d8"},
     {file = "libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl", hash = "sha256:c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b"},
@@ -5444,13 +5445,13 @@ fire = "*"
 
 [[package]]
 name = "rasa-pro"
-version = "3.10.0"
+version = "3.10.1"
 description = "State-of-the-art open-core Conversational AI framework for Enterprises that natively leverages generative AI for effortless assistant development."
 optional = false
 python-versions = ">=3.8.1,<3.11"
 files = [
-    {file = "rasa_pro-3.10.0-py3-none-any.whl", hash = "sha256:206262ce346392609643af9a17b2fdd259206483a0847ec4b4f38fb89e8eb4ea"},
-    {file = "rasa_pro-3.10.0.tar.gz", hash = "sha256:0b1ead8911212de002c5e87f7897b974cd2bef7896d1da5ddddf28db6635a47a"},
+    {file = "rasa_pro-3.10.1-py3-none-any.whl", hash = "sha256:408fd74f8dfca4417976377ce3c8d5b8d685b7e44c6f0e2fed8d6d022b49213a"},
+    {file = "rasa_pro-3.10.1.tar.gz", hash = "sha256:a60b5ae6d8bd3e5b687b8951079baff9d5b6f2391ca207282257e272f0f1c332"},
 ]
 
 [package.dependencies]
@@ -8092,4 +8093,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "eadc7fd58b54b314489527296f6cd42a39b598c5cf19f22ffa7beba153c1caa2"
+content-hash = "06b45d688de072d4d8d9618d6efc05297a7bcfbb45c9099c6290d61d9f7cd861"

--- a/poetry.lock
+++ b/poetry.lock
@@ -203,6 +203,41 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "alembic"
+version = "1.13.2"
+description = "A database migration tool for SQLAlchemy."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "alembic-1.13.2-py3-none-any.whl", hash = "sha256:6b8733129a6224a9a711e17c99b08462dbf7cc9670ba8f2e2ae9af860ceb1953"},
+    {file = "alembic-1.13.2.tar.gz", hash = "sha256:1ff0ae32975f4fd96028c39ed9bb3c867fe3af956bd7bb37343b54c9fe7445ef"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.9\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.9\""}
+Mako = "*"
+SQLAlchemy = ">=1.3.0"
+typing-extensions = ">=4"
+
+[package.extras]
+tz = ["backports.zoneinfo"]
+
+[[package]]
+name = "aniso8601"
+version = "9.0.1"
+description = "A library for parsing ISO 8601 strings."
+optional = false
+python-versions = "*"
+files = [
+    {file = "aniso8601-9.0.1-py2.py3-none-any.whl", hash = "sha256:1d2b7ef82963909e93c4f24ce48d4de9e66009a21bf1c1e1c85bdd0812fe412f"},
+    {file = "aniso8601-9.0.1.tar.gz", hash = "sha256:72e3117667eedf66951bb2d93f4296a56b94b078a8a95905a052611fb3f1b973"},
+]
+
+[package.extras]
+dev = ["black", "coverage", "isort", "pre-commit", "pyenchant", "pylint"]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -416,6 +451,17 @@ files = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.8.2"
+description = "Fast, simple object-to-object and broadcast signaling"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "blinker-1.8.2-py3-none-any.whl", hash = "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01"},
+    {file = "blinker-1.8.2.tar.gz", hash = "sha256:8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"},
+]
+
+[[package]]
 name = "blis"
 version = "0.7.11"
 description = "The Blis BLAS-like linear algebra library, as a self-contained C-extension."
@@ -460,50 +506,47 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.19.0", markers = "python_version >= \"3.9\""},
     {version = ">=1.15.0", markers = "python_version < \"3.9\""},
+    {version = ">=1.19.0", markers = "python_version >= \"3.9\""},
 ]
 
 [[package]]
 name = "boto3"
-version = "1.34.134"
+version = "1.27.1"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.34.134-py3-none-any.whl", hash = "sha256:342782c02ff077aae118c9c61179eed95c585831fba666baacc5588ff04aa6e1"},
-    {file = "boto3-1.34.134.tar.gz", hash = "sha256:f6d6e5b0c9ab022a75373fa16c01f0cd54bc1bb64ef3b6ac64ac7cedd56cbe9c"},
+    {file = "boto3-1.27.1-py3-none-any.whl", hash = "sha256:0085c1066953e61915b34f24fbdee7117fd2d8b5c9188b9519d47ba84510c067"},
+    {file = "boto3-1.27.1.tar.gz", hash = "sha256:cf43deb4556295219d9de44d1c95921209c90ee25246673b5768aef9d46519cc"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.134,<1.35.0"
+botocore = ">=1.30.1,<1.31.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.10.0,<0.11.0"
+s3transfer = ">=0.6.0,<0.7.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.134"
+version = "1.30.1"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.34.134-py3-none-any.whl", hash = "sha256:45219e00639755f92569b29f8f279d5dde721494791412c1f7026a3779e8d9f4"},
-    {file = "botocore-1.34.134.tar.gz", hash = "sha256:e29c299599426ed16dd2d4c1e20eef784f96b15e1850ebbc59a3250959285b95"},
+    {file = "botocore-1.30.1-py3-none-any.whl", hash = "sha256:18a32a21bfa9b418b9a38ea5ef4464eba003cbb26fca2cd56e4f51098c5d1a0f"},
+    {file = "botocore-1.30.1.tar.gz", hash = "sha256:4d1ac5a796c5c5c87946f25f3d98764288a0ed848e772a7a47cd134847e885e7"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = [
-    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
-    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
-]
+urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.20.11)"]
+crt = ["awscrt (==0.16.9)"]
 
 [[package]]
 name = "cachecontrol"
@@ -1110,6 +1153,25 @@ distributed = ["distributed (==2022.10.2)"]
 test = ["pandas[test]", "pre-commit", "pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 [[package]]
+name = "databricks-sdk"
+version = "0.30.0"
+description = "Databricks SDK for Python (Beta)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "databricks_sdk-0.30.0-py3-none-any.whl", hash = "sha256:c3f954c73cdd703815acfa31a2e8442ee85aa3ca3ba8d52f05e85ebce29233d7"},
+    {file = "databricks_sdk-0.30.0.tar.gz", hash = "sha256:37c7a12939da09dbdcb6ceba4fcad5f484a63508366225f797429ae4ee557b21"},
+]
+
+[package.dependencies]
+google-auth = ">=2.0,<3.0"
+requests = ">=2.28.1,<3"
+
+[package.extras]
+dev = ["autoflake", "databricks-connect", "ipython", "ipywidgets", "isort", "pycodestyle", "pyfakefs", "pytest", "pytest-cov", "pytest-mock", "pytest-rerunfailures", "pytest-xdist", "requests-mock", "wheel", "yapf"]
+notebook = ["ipython (>=8,<9)", "ipywidgets (>=8,<9)"]
+
+[[package]]
 name = "dataclasses-json"
 version = "0.6.7"
 description = "Easily serialize dataclasses to and from JSON."
@@ -1156,6 +1218,28 @@ files = [
 packaging = "*"
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+description = "Disk Cache -- Disk and file backed persistent cache."
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19"},
+    {file = "diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc"},
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+description = "Distro - an OS platform information API"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
 name = "dnspython"
 version = "2.6.1"
 description = "DNS toolkit"
@@ -1176,6 +1260,28 @@ trio = ["trio (>=0.23)"]
 wmi = ["wmi (>=1.5.1)"]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+description = "A Python library for the Docker Engine API."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"},
+    {file = "docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"},
+]
+
+[package.dependencies]
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+dev = ["coverage (==7.2.7)", "pytest (==7.4.2)", "pytest-cov (==4.1.0)", "pytest-timeout (==2.1.0)", "ruff (==0.1.8)"]
+docs = ["myst-parser (==0.18.0)", "sphinx (==5.1.1)"]
+ssh = ["paramiko (>=2.4.3)"]
+websockets = ["websocket-client (>=1.3.0)"]
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 description = "Pythonic argument parser, that will make you smile"
@@ -1183,6 +1289,17 @@ optional = false
 python-versions = "*"
 files = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
+]
+
+[[package]]
+name = "entrypoints"
+version = "0.4"
+description = "Discover and load entry points from installed packages."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
+    {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
 ]
 
 [[package]]
@@ -1205,6 +1322,17 @@ dev = ["dj-database-url", "dj-email-url", "django-cache-url", "flake8 (==4.0.1)"
 django = ["dj-database-url", "dj-email-url", "django-cache-url"]
 lint = ["flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "mypy (==0.910)", "pre-commit (>=2.4,<3.0)"]
 tests = ["dj-database-url", "dj-email-url", "django-cache-url", "pytest"]
+
+[[package]]
+name = "et-xmlfile"
+version = "1.1.0"
+description = "An implementation of lxml.xmlfile for the standard library"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "et_xmlfile-1.1.0-py3-none-any.whl", hash = "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"},
+    {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
+]
 
 [[package]]
 name = "exceptiongroup"
@@ -1261,18 +1389,17 @@ packaging = "*"
 
 [[package]]
 name = "faker"
-version = "19.13.0"
+version = "26.3.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-19.13.0-py3-none-any.whl", hash = "sha256:da880a76322db7a879c848a0771e129338e0a680a9f695fd9a3e7a6ac82b45e1"},
-    {file = "Faker-19.13.0.tar.gz", hash = "sha256:14ccb0aec342d33aa3889a864a56e5b3c2d56bce1b89f9189f4fbc128b9afc1e"},
+    {file = "Faker-26.3.0-py3-none-any.whl", hash = "sha256:97fe1e7e953dd640ca2cd4dfac4db7c4d2432dd1b7a244a3313517707f3b54e9"},
+    {file = "Faker-26.3.0.tar.gz", hash = "sha256:7c10ebdf74aaa0cc4fe6ec6db5a71e8598ec33503524bd4b5f4494785a5670dd"},
 ]
 
 [package.dependencies]
 python-dateutil = ">=2.4"
-typing-extensions = {version = ">=3.10.0.1", markers = "python_version <= \"3.8\""}
 
 [[package]]
 name = "fbmessenger"
@@ -1317,6 +1444,29 @@ files = [
 [package.dependencies]
 six = "*"
 termcolor = "*"
+
+[[package]]
+name = "flask"
+version = "3.0.3"
+description = "A simple framework for building complex web applications."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "flask-3.0.3-py3-none-any.whl", hash = "sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3"},
+    {file = "flask-3.0.3.tar.gz", hash = "sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842"},
+]
+
+[package.dependencies]
+blinker = ">=1.6.2"
+click = ">=8.1.3"
+importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
+itsdangerous = ">=2.1.2"
+Jinja2 = ">=3.1.2"
+Werkzeug = ">=3.0.0"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
 
 [[package]]
 name = "flatbuffers"
@@ -1540,6 +1690,38 @@ files = [
     {file = "gast-0.4.0-py3-none-any.whl", hash = "sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4"},
     {file = "gast-0.4.0.tar.gz", hash = "sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1"},
 ]
+
+[[package]]
+name = "gitdb"
+version = "4.0.11"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "gitdb-4.0.11-py3-none-any.whl", hash = "sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4"},
+    {file = "gitdb-4.0.11.tar.gz", hash = "sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.43"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"},
+    {file = "GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-applehelp (>=1.0.2,<=1.0.4)", "sphinxcontrib-devhelp (==1.0.2)", "sphinxcontrib-htmlhelp (>=2.0.0,<=2.0.1)", "sphinxcontrib-qthelp (==1.0.3)", "sphinxcontrib-serializinghtml (==1.1.5)"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
 
 [[package]]
 name = "google-api-core"
@@ -1775,6 +1957,51 @@ protobuf = ">=3.15.0"
 grpc = ["grpcio (>=1.0.0)"]
 
 [[package]]
+name = "graphene"
+version = "3.3"
+description = "GraphQL Framework for Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "graphene-3.3-py2.py3-none-any.whl", hash = "sha256:bb3810be33b54cb3e6969506671eb72319e8d7ba0d5ca9c8066472f75bf35a38"},
+    {file = "graphene-3.3.tar.gz", hash = "sha256:529bf40c2a698954217d3713c6041d69d3f719ad0080857d7ee31327112446b0"},
+]
+
+[package.dependencies]
+aniso8601 = ">=8,<10"
+graphql-core = ">=3.1,<3.3"
+graphql-relay = ">=3.1,<3.3"
+
+[package.extras]
+dev = ["black (==22.3.0)", "coveralls (>=3.3,<4)", "flake8 (>=4,<5)", "iso8601 (>=1,<2)", "mock (>=4,<5)", "pytest (>=6,<7)", "pytest-asyncio (>=0.16,<2)", "pytest-benchmark (>=3.4,<4)", "pytest-cov (>=3,<4)", "pytest-mock (>=3,<4)", "pytz (==2022.1)", "snapshottest (>=0.6,<1)"]
+test = ["coveralls (>=3.3,<4)", "iso8601 (>=1,<2)", "mock (>=4,<5)", "pytest (>=6,<7)", "pytest-asyncio (>=0.16,<2)", "pytest-benchmark (>=3.4,<4)", "pytest-cov (>=3,<4)", "pytest-mock (>=3,<4)", "pytz (==2022.1)", "snapshottest (>=0.6,<1)"]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.3"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+optional = false
+python-versions = ">=3.6,<4"
+files = [
+    {file = "graphql-core-3.2.3.tar.gz", hash = "sha256:06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676"},
+    {file = "graphql_core-3.2.3-py3-none-any.whl", hash = "sha256:5766780452bd5ec8ba133f8bf287dc92713e3868ddd83aee4faab9fc3e303dc3"},
+]
+
+[[package]]
+name = "graphql-relay"
+version = "3.2.0"
+description = "Relay library for graphql-core"
+optional = false
+python-versions = ">=3.6,<4"
+files = [
+    {file = "graphql-relay-3.2.0.tar.gz", hash = "sha256:1ff1c51298356e481a0be009ccdff249832ce53f30559c1338f22a0e0d17250c"},
+    {file = "graphql_relay-3.2.0-py3-none-any.whl", hash = "sha256:c9b22bd28b170ba1fe674c74384a8ff30a76c8e26f88ac3aa1584dd3179953e5"},
+]
+
+[package.dependencies]
+graphql-core = ">=3.2,<3.3"
+
+[[package]]
 name = "greenlet"
 version = "3.0.3"
 description = "Lightweight in-process concurrent programming"
@@ -1912,6 +2139,21 @@ files = [
 protobuf = ["grpcio-tools (>=1.59.3)"]
 
 [[package]]
+name = "grpcio-health-checking"
+version = "1.59.3"
+description = "Standard Health Checking Service for gRPC"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "grpcio-health-checking-1.59.3.tar.gz", hash = "sha256:015017ce4164fc7dce81da3a1718a4b3153230e481b2cdebf392468b613f0766"},
+    {file = "grpcio_health_checking-1.59.3-py3-none-any.whl", hash = "sha256:30b0184173d5a7a48788b1643968a9f75154b2bf8d47baf795c03402727a84cf"},
+]
+
+[package.dependencies]
+grpcio = ">=1.59.3"
+protobuf = ">=4.21.6"
+
+[[package]]
 name = "grpcio-tools"
 version = "1.56.2"
 description = "Protobuf code generator for gRPC"
@@ -1969,6 +2211,27 @@ files = [
 grpcio = ">=1.56.2"
 protobuf = ">=4.21.6,<5.0dev"
 setuptools = "*"
+
+[[package]]
+name = "gunicorn"
+version = "22.0.0"
+description = "WSGI HTTP Server for UNIX"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "gunicorn-22.0.0-py3-none-any.whl", hash = "sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9"},
+    {file = "gunicorn-22.0.0.tar.gz", hash = "sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
+tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "h11"
@@ -2135,6 +2398,40 @@ http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 
 [[package]]
+name = "huggingface-hub"
+version = "0.24.6"
+description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "huggingface_hub-0.24.6-py3-none-any.whl", hash = "sha256:a990f3232aa985fe749bc9474060cbad75e8b2f115f6665a9fda5b9c97818970"},
+    {file = "huggingface_hub-0.24.6.tar.gz", hash = "sha256:cc2579e761d070713eaa9c323e3debe39d5b464ae3a7261c39a9195b27bb8000"},
+]
+
+[package.dependencies]
+filelock = "*"
+fsspec = ">=2023.5.0"
+packaging = ">=20.9"
+pyyaml = ">=5.1"
+requests = "*"
+tqdm = ">=4.42.1"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio", "jedi", "minijinja (>=1.0)", "mypy (==1.5.1)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.5.0)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+cli = ["InquirerPy (==0.3.4)"]
+dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio", "jedi", "minijinja (>=1.0)", "mypy (==1.5.1)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.5.0)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
+hf-transfer = ["hf-transfer (>=0.1.4)"]
+inference = ["aiohttp", "minijinja (>=1.0)"]
+quality = ["mypy (==1.5.1)", "ruff (>=0.5.0)"]
+tensorflow = ["graphviz", "pydot", "tensorflow"]
+tensorflow-testing = ["keras (<3.0)", "tensorflow"]
+testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio", "jedi", "minijinja (>=1.0)", "numpy", "pytest (>=8.1.1,<8.2.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
+torch = ["safetensors[torch]", "torch"]
+typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
+
+[[package]]
 name = "humanfriendly"
 version = "10.0"
 description = "Human friendly output for text interfaces using Python"
@@ -2237,6 +2534,17 @@ files = [
 six = "*"
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+description = "Safely pass data to untrusted environments and back."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef"},
+    {file = "itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"},
+]
+
+[[package]]
 name = "jax"
 version = "0.4.13"
 description = "Differentiate, compile, and transform Numpy code."
@@ -2282,6 +2590,76 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jiter"
+version = "0.5.0"
+description = "Fast iterable JSON parser."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jiter-0.5.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:b599f4e89b3def9a94091e6ee52e1d7ad7bc33e238ebb9c4c63f211d74822c3f"},
+    {file = "jiter-0.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a063f71c4b06225543dddadbe09d203dc0c95ba352d8b85f1221173480a71d5"},
+    {file = "jiter-0.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc0d5b8b3dd12e91dd184b87273f864b363dfabc90ef29a1092d269f18c7e28"},
+    {file = "jiter-0.5.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c22541f0b672f4d741382a97c65609332a783501551445ab2df137ada01e019e"},
+    {file = "jiter-0.5.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63314832e302cc10d8dfbda0333a384bf4bcfce80d65fe99b0f3c0da8945a91a"},
+    {file = "jiter-0.5.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a25fbd8a5a58061e433d6fae6d5298777c0814a8bcefa1e5ecfff20c594bd749"},
+    {file = "jiter-0.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:503b2c27d87dfff5ab717a8200fbbcf4714516c9d85558048b1fc14d2de7d8dc"},
+    {file = "jiter-0.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d1f3d27cce923713933a844872d213d244e09b53ec99b7a7fdf73d543529d6d"},
+    {file = "jiter-0.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c95980207b3998f2c3b3098f357994d3fd7661121f30669ca7cb945f09510a87"},
+    {file = "jiter-0.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:afa66939d834b0ce063f57d9895e8036ffc41c4bd90e4a99631e5f261d9b518e"},
+    {file = "jiter-0.5.0-cp310-none-win32.whl", hash = "sha256:f16ca8f10e62f25fd81d5310e852df6649af17824146ca74647a018424ddeccf"},
+    {file = "jiter-0.5.0-cp310-none-win_amd64.whl", hash = "sha256:b2950e4798e82dd9176935ef6a55cf6a448b5c71515a556da3f6b811a7844f1e"},
+    {file = "jiter-0.5.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d4c8e1ed0ef31ad29cae5ea16b9e41529eb50a7fba70600008e9f8de6376d553"},
+    {file = "jiter-0.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c6f16e21276074a12d8421692515b3fd6d2ea9c94fd0734c39a12960a20e85f3"},
+    {file = "jiter-0.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5280e68e7740c8c128d3ae5ab63335ce6d1fb6603d3b809637b11713487af9e6"},
+    {file = "jiter-0.5.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:583c57fc30cc1fec360e66323aadd7fc3edeec01289bfafc35d3b9dcb29495e4"},
+    {file = "jiter-0.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26351cc14507bdf466b5f99aba3df3143a59da75799bf64a53a3ad3155ecded9"},
+    {file = "jiter-0.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4829df14d656b3fb87e50ae8b48253a8851c707da9f30d45aacab2aa2ba2d614"},
+    {file = "jiter-0.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a42a4bdcf7307b86cb863b2fb9bb55029b422d8f86276a50487982d99eed7c6e"},
+    {file = "jiter-0.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04d461ad0aebf696f8da13c99bc1b3e06f66ecf6cfd56254cc402f6385231c06"},
+    {file = "jiter-0.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e6375923c5f19888c9226582a124b77b622f8fd0018b843c45eeb19d9701c403"},
+    {file = "jiter-0.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2cec323a853c24fd0472517113768c92ae0be8f8c384ef4441d3632da8baa646"},
+    {file = "jiter-0.5.0-cp311-none-win32.whl", hash = "sha256:aa1db0967130b5cab63dfe4d6ff547c88b2a394c3410db64744d491df7f069bb"},
+    {file = "jiter-0.5.0-cp311-none-win_amd64.whl", hash = "sha256:aa9d2b85b2ed7dc7697597dcfaac66e63c1b3028652f751c81c65a9f220899ae"},
+    {file = "jiter-0.5.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9f664e7351604f91dcdd557603c57fc0d551bc65cc0a732fdacbf73ad335049a"},
+    {file = "jiter-0.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:044f2f1148b5248ad2c8c3afb43430dccf676c5a5834d2f5089a4e6c5bbd64df"},
+    {file = "jiter-0.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:702e3520384c88b6e270c55c772d4bd6d7b150608dcc94dea87ceba1b6391248"},
+    {file = "jiter-0.5.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:528d742dcde73fad9d63e8242c036ab4a84389a56e04efd854062b660f559544"},
+    {file = "jiter-0.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8cf80e5fe6ab582c82f0c3331df27a7e1565e2dcf06265afd5173d809cdbf9ba"},
+    {file = "jiter-0.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:44dfc9ddfb9b51a5626568ef4e55ada462b7328996294fe4d36de02fce42721f"},
+    {file = "jiter-0.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c451f7922992751a936b96c5f5b9bb9312243d9b754c34b33d0cb72c84669f4e"},
+    {file = "jiter-0.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:308fce789a2f093dca1ff91ac391f11a9f99c35369117ad5a5c6c4903e1b3e3a"},
+    {file = "jiter-0.5.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7f5ad4a7c6b0d90776fdefa294f662e8a86871e601309643de30bf94bb93a64e"},
+    {file = "jiter-0.5.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ea189db75f8eca08807d02ae27929e890c7d47599ce3d0a6a5d41f2419ecf338"},
+    {file = "jiter-0.5.0-cp312-none-win32.whl", hash = "sha256:e3bbe3910c724b877846186c25fe3c802e105a2c1fc2b57d6688b9f8772026e4"},
+    {file = "jiter-0.5.0-cp312-none-win_amd64.whl", hash = "sha256:a586832f70c3f1481732919215f36d41c59ca080fa27a65cf23d9490e75b2ef5"},
+    {file = "jiter-0.5.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:f04bc2fc50dc77be9d10f73fcc4e39346402ffe21726ff41028f36e179b587e6"},
+    {file = "jiter-0.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6f433a4169ad22fcb550b11179bb2b4fd405de9b982601914ef448390b2954f3"},
+    {file = "jiter-0.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad4a6398c85d3a20067e6c69890ca01f68659da94d74c800298581724e426c7e"},
+    {file = "jiter-0.5.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6baa88334e7af3f4d7a5c66c3a63808e5efbc3698a1c57626541ddd22f8e4fbf"},
+    {file = "jiter-0.5.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ece0a115c05efca597c6d938f88c9357c843f8c245dbbb53361a1c01afd7148"},
+    {file = "jiter-0.5.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:335942557162ad372cc367ffaf93217117401bf930483b4b3ebdb1223dbddfa7"},
+    {file = "jiter-0.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:649b0ee97a6e6da174bffcb3c8c051a5935d7d4f2f52ea1583b5b3e7822fbf14"},
+    {file = "jiter-0.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f4be354c5de82157886ca7f5925dbda369b77344b4b4adf2723079715f823989"},
+    {file = "jiter-0.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5206144578831a6de278a38896864ded4ed96af66e1e63ec5dd7f4a1fce38a3a"},
+    {file = "jiter-0.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8120c60f8121ac3d6f072b97ef0e71770cc72b3c23084c72c4189428b1b1d3b6"},
+    {file = "jiter-0.5.0-cp38-none-win32.whl", hash = "sha256:6f1223f88b6d76b519cb033a4d3687ca157c272ec5d6015c322fc5b3074d8a5e"},
+    {file = "jiter-0.5.0-cp38-none-win_amd64.whl", hash = "sha256:c59614b225d9f434ea8fc0d0bec51ef5fa8c83679afedc0433905994fb36d631"},
+    {file = "jiter-0.5.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:0af3838cfb7e6afee3f00dc66fa24695199e20ba87df26e942820345b0afc566"},
+    {file = "jiter-0.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:550b11d669600dbc342364fd4adbe987f14d0bbedaf06feb1b983383dcc4b961"},
+    {file = "jiter-0.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:489875bf1a0ffb3cb38a727b01e6673f0f2e395b2aad3c9387f94187cb214bbf"},
+    {file = "jiter-0.5.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b250ca2594f5599ca82ba7e68785a669b352156260c5362ea1b4e04a0f3e2389"},
+    {file = "jiter-0.5.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ea18e01f785c6667ca15407cd6dabbe029d77474d53595a189bdc813347218e"},
+    {file = "jiter-0.5.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:462a52be85b53cd9bffd94e2d788a09984274fe6cebb893d6287e1c296d50653"},
+    {file = "jiter-0.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92cc68b48d50fa472c79c93965e19bd48f40f207cb557a8346daa020d6ba973b"},
+    {file = "jiter-0.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1c834133e59a8521bc87ebcad773608c6fa6ab5c7a022df24a45030826cf10bc"},
+    {file = "jiter-0.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ab3a71ff31cf2d45cb216dc37af522d335211f3a972d2fe14ea99073de6cb104"},
+    {file = "jiter-0.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:cccd3af9c48ac500c95e1bcbc498020c87e1781ff0345dd371462d67b76643eb"},
+    {file = "jiter-0.5.0-cp39-none-win32.whl", hash = "sha256:368084d8d5c4fc40ff7c3cc513c4f73e02c85f6009217922d0823a48ee7adf61"},
+    {file = "jiter-0.5.0-cp39-none-win_amd64.whl", hash = "sha256:ce03f7b4129eb72f1687fa11300fbf677b02990618428934662406d2a76742a1"},
+    {file = "jiter-0.5.0.tar.gz", hash = "sha256:1d916ba875bcab5c5f7d927df998c4cb694d27dceddf3392e58beaf10563368a"},
+]
 
 [[package]]
 name = "jmespath"
@@ -2348,13 +2726,13 @@ files = [
 
 [[package]]
 name = "jsonschema"
-version = "4.20.0"
+version = "4.23.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jsonschema-4.20.0-py3-none-any.whl", hash = "sha256:ed6231f0429ecf966f5bc8dfef245998220549cbbcf140f913b7464c52c3b6b3"},
-    {file = "jsonschema-4.20.0.tar.gz", hash = "sha256:4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa"},
+    {file = "jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"},
+    {file = "jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4"},
 ]
 
 [package.dependencies]
@@ -2367,7 +2745,7 @@ rpds-py = ">=0.7.1"
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=24.6.0)"]
 
 [[package]]
 name = "jsonschema-specifications"
@@ -2524,43 +2902,84 @@ files = [
 
 [[package]]
 name = "langchain"
-version = "0.0.329"
+version = "0.2.14"
 description = "Building applications with LLMs through composability"
 optional = false
-python-versions = ">=3.8.1,<4.0"
+python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langchain-0.0.329-py3-none-any.whl", hash = "sha256:5f3e884991271e8b55eda4c63a11105dcd7da119682ce0e3d5d1385b3a4103d2"},
-    {file = "langchain-0.0.329.tar.gz", hash = "sha256:488f3cb68a587696f136d4f01f97df8d8270e295b3cc56158057dab0f61f4166"},
+    {file = "langchain-0.2.14-py3-none-any.whl", hash = "sha256:eed76194ee7d9c081037a3df7868d4de90e0410b51fc1ca933a8379e464bf40c"},
+    {file = "langchain-0.2.14.tar.gz", hash = "sha256:dc2aa5a58882054fb5d043c39ab8332ebd055f88f17839da68e1c7fd0a4fefe2"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.8.3,<4.0.0"
-anyio = "<4.0"
 async-timeout = {version = ">=4.0.0,<5.0.0", markers = "python_version < \"3.11\""}
-dataclasses-json = ">=0.5.7,<0.7"
-jsonpatch = ">=1.33,<2.0"
-langsmith = ">=0.0.52,<0.1.0"
-numpy = ">=1,<2"
+langchain-core = ">=0.2.32,<0.3.0"
+langchain-text-splitters = ">=0.2.0,<0.3.0"
+langsmith = ">=0.1.17,<0.2.0"
+numpy = {version = ">=1,<2", markers = "python_version < \"3.12\""}
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
 requests = ">=2,<3"
 SQLAlchemy = ">=1.4,<3"
-tenacity = ">=8.1.0,<9.0.0"
+tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<9.0.0"
 
-[package.extras]
-all = ["O365 (>=2.0.26,<3.0.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "amadeus (>=8.1.0)", "arxiv (>=1.4,<2.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "awadb (>=0.3.9,<0.4.0)", "azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "beautifulsoup4 (>=4,<5)", "clarifai (>=9.1.0)", "clickhouse-connect (>=0.5.14,<0.6.0)", "cohere (>=4,<5)", "deeplake (>=3.8.3,<4.0.0)", "docarray[hnswlib] (>=0.32.0,<0.33.0)", "duckduckgo-search (>=3.8.3,<4.0.0)", "elasticsearch (>=8,<9)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "google-api-python-client (==2.70.0)", "google-auth (>=2.18.1,<3.0.0)", "google-search-results (>=2,<3)", "gptcache (>=0.1.7)", "html2text (>=2020.1.16,<2021.0.0)", "huggingface_hub (>=0,<1)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "lancedb (>=0.1,<0.2)", "langkit (>=0.0.6,<0.1.0)", "lark (>=1.1.5,<2.0.0)", "librosa (>=0.10.0.post2,<0.11.0)", "lxml (>=4.9.2,<5.0.0)", "manifest-ml (>=0.0.1,<0.0.2)", "marqo (>=1.2.4,<2.0.0)", "momento (>=1.10.1,<2.0.0)", "nebula3-python (>=3.4.0,<4.0.0)", "neo4j (>=5.8.1,<6.0.0)", "networkx (>=2.6.3,<4)", "nlpcloud (>=1,<2)", "nltk (>=3,<4)", "nomic (>=1.0.43,<2.0.0)", "openai (>=0,<1)", "openlm (>=0.0.5,<0.0.6)", "opensearch-py (>=2.0.0,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pexpect (>=4.8.0,<5.0.0)", "pgvector (>=0.1.6,<0.2.0)", "pinecone-client (>=2,<3)", "pinecone-text (>=0.4.2,<0.5.0)", "psycopg2-binary (>=2.9.5,<3.0.0)", "pymongo (>=4.3.3,<5.0.0)", "pyowm (>=3.3.0,<4.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pytesseract (>=0.3.10,<0.4.0)", "python-arango (>=7.5.9,<8.0.0)", "pyvespa (>=0.33.0,<0.34.0)", "qdrant-client (>=1.3.1,<2.0.0)", "rdflib (>=6.3.2,<7.0.0)", "redis (>=4,<5)", "requests-toolbelt (>=1.0.0,<2.0.0)", "sentence-transformers (>=2,<3)", "singlestoredb (>=0.7.1,<0.8.0)", "tensorflow-text (>=2.11.0,<3.0.0)", "tigrisdb (>=1.0.0b6,<2.0.0)", "tiktoken (>=0.3.2,<0.6.0)", "torch (>=1,<3)", "transformers (>=4,<5)", "weaviate-client (>=3,<4)", "wikipedia (>=1,<2)", "wolframalpha (==5.0.0)"]
-azure = ["azure-ai-formrecognizer (>=3.2.1,<4.0.0)", "azure-ai-vision (>=0.11.1b1,<0.12.0)", "azure-cognitiveservices-speech (>=1.28.0,<2.0.0)", "azure-core (>=1.26.4,<2.0.0)", "azure-cosmos (>=4.4.0b1,<5.0.0)", "azure-identity (>=1.12.0,<2.0.0)", "azure-search-documents (==11.4.0b8)", "openai (>=0,<1)"]
-clarifai = ["clarifai (>=9.1.0)"]
-cli = ["typer (>=0.9.0,<0.10.0)"]
-cohere = ["cohere (>=4,<5)"]
-docarray = ["docarray[hnswlib] (>=0.32.0,<0.33.0)"]
-embeddings = ["sentence-transformers (>=2,<3)"]
-extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.0,<3.0.0)", "anthropic (>=0.3.11,<0.4.0)", "arxiv (>=1.4,<2.0)", "assemblyai (>=0.17.0,<0.18.0)", "atlassian-python-api (>=3.36.0,<4.0.0)", "beautifulsoup4 (>=4,<5)", "bibtexparser (>=1.4.0,<2.0.0)", "cassio (>=0.1.0,<0.2.0)", "chardet (>=5.1.0,<6.0.0)", "dashvector (>=1.0.1,<2.0.0)", "esprima (>=4.0.1,<5.0.0)", "faiss-cpu (>=1,<2)", "feedparser (>=6.0.10,<7.0.0)", "fireworks-ai (>=0.6.0,<0.7.0)", "geopandas (>=0.13.1,<0.14.0)", "gitpython (>=3.1.32,<4.0.0)", "google-cloud-documentai (>=2.20.1,<3.0.0)", "gql (>=3.4.1,<4.0.0)", "html2text (>=2020.1.16,<2021.0.0)", "jinja2 (>=3,<4)", "jq (>=1.4.1,<2.0.0)", "jsonschema (>1)", "lxml (>=4.9.2,<5.0.0)", "markdownify (>=0.11.6,<0.12.0)", "motor (>=3.3.1,<4.0.0)", "mwparserfromhell (>=0.6.4,<0.7.0)", "mwxml (>=0.3.3,<0.4.0)", "newspaper3k (>=0.2.8,<0.3.0)", "numexpr (>=2.8.6,<3.0.0)", "openai (>=0,<1)", "openapi-pydantic (>=0.3.2,<0.4.0)", "pandas (>=2.0.1,<3.0.0)", "pdfminer-six (>=20221105,<20221106)", "pgvector (>=0.1.6,<0.2.0)", "psychicapi (>=0.8.0,<0.9.0)", "py-trello (>=0.19.0,<0.20.0)", "pymupdf (>=1.22.3,<2.0.0)", "pypdf (>=3.4.0,<4.0.0)", "pypdfium2 (>=4.10.0,<5.0.0)", "pyspark (>=3.4.0,<4.0.0)", "rank-bm25 (>=0.2.2,<0.3.0)", "rapidfuzz (>=3.1.1,<4.0.0)", "rapidocr-onnxruntime (>=1.3.2,<2.0.0)", "requests-toolbelt (>=1.0.0,<2.0.0)", "rspace_client (>=2.5.0,<3.0.0)", "scikit-learn (>=1.2.2,<2.0.0)", "sqlite-vss (>=0.1.2,<0.2.0)", "streamlit (>=1.18.0,<2.0.0)", "sympy (>=1.12,<2.0)", "telethon (>=1.28.5,<2.0.0)", "timescale-vector (>=0.0.1,<0.0.2)", "tqdm (>=4.48.0)", "upstash-redis (>=0.15.0,<0.16.0)", "xata (>=1.0.0a7,<2.0.0)", "xmltodict (>=0.13.0,<0.14.0)"]
-javascript = ["esprima (>=4.0.1,<5.0.0)"]
-llms = ["clarifai (>=9.1.0)", "cohere (>=4,<5)", "huggingface_hub (>=0,<1)", "manifest-ml (>=0.0.1,<0.0.2)", "nlpcloud (>=1,<2)", "openai (>=0,<1)", "openlm (>=0.0.5,<0.0.6)", "torch (>=1,<3)", "transformers (>=4,<5)"]
-openai = ["openai (>=0,<1)", "tiktoken (>=0.3.2,<0.6.0)"]
-qdrant = ["qdrant-client (>=1.3.1,<2.0.0)"]
-text-helpers = ["chardet (>=5.1.0,<6.0.0)"]
+[[package]]
+name = "langchain-community"
+version = "0.2.12"
+description = "Community contributed LangChain integrations."
+optional = false
+python-versions = "<4.0,>=3.8.1"
+files = [
+    {file = "langchain_community-0.2.12-py3-none-any.whl", hash = "sha256:50e74473dd2309bdef561760afbbf0c5ea17ed91fc4dfa0d52279dd16d6d34e0"},
+    {file = "langchain_community-0.2.12.tar.gz", hash = "sha256:d671cfc6a4f3b65f49a2e59ab420d0164f109d0a56fc4b4996518205c63b8c7e"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.8.3,<4.0.0"
+dataclasses-json = ">=0.5.7,<0.7"
+langchain = ">=0.2.13,<0.3.0"
+langchain-core = ">=0.2.30,<0.3.0"
+langsmith = ">=0.1.0,<0.2.0"
+numpy = {version = ">=1,<2", markers = "python_version < \"3.12\""}
+PyYAML = ">=5.3"
+requests = ">=2,<3"
+SQLAlchemy = ">=1.4,<3"
+tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<9.0.0"
+
+[[package]]
+name = "langchain-core"
+version = "0.2.33"
+description = "Building applications with LLMs through composability"
+optional = false
+python-versions = "<4.0,>=3.8.1"
+files = [
+    {file = "langchain_core-0.2.33-py3-none-any.whl", hash = "sha256:c8de411336c13fa440b7a52895bfd1c064f04d315344855962988483902cc532"},
+    {file = "langchain_core-0.2.33.tar.gz", hash = "sha256:dd2659e0a560fc987b210107bf989aa14a6f4b67dd214c13a2c9669036cda975"},
+]
+
+[package.dependencies]
+jsonpatch = ">=1.33,<2.0"
+langsmith = ">=0.1.75,<0.2.0"
+packaging = ">=23.2,<25"
+pydantic = {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""}
+PyYAML = ">=5.3"
+tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<9.0.0"
+typing-extensions = ">=4.7"
+
+[[package]]
+name = "langchain-text-splitters"
+version = "0.2.2"
+description = "LangChain text splitting utilities"
+optional = false
+python-versions = "<4.0,>=3.8.1"
+files = [
+    {file = "langchain_text_splitters-0.2.2-py3-none-any.whl", hash = "sha256:1c80d4b11b55e2995f02d2a326c0323ee1eeff24507329bb22924e420c782dff"},
+    {file = "langchain_text_splitters-0.2.2.tar.gz", hash = "sha256:a1e45de10919fa6fb080ef0525deab56557e9552083600455cb9fa4238076140"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.2.10,<0.3.0"
 
 [[package]]
 name = "langcodes"
@@ -2582,17 +3001,19 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "langsmith"
-version = "0.0.92"
+version = "0.1.100"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
-python-versions = ">=3.8.1,<4.0"
+python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.0.92-py3-none-any.whl", hash = "sha256:ddcf65e3b5ca11893ae8ef9816ce2a11a089d051be491886e43a2c4556b88fd0"},
-    {file = "langsmith-0.0.92.tar.gz", hash = "sha256:61a3a502222bdd221b7f592b6fc14756d74c4fc088aa6bd8834b92adfe9ee583"},
+    {file = "langsmith-0.1.100-py3-none-any.whl", hash = "sha256:cae44a884a4166c4d8b9cc5ff99f5d520337bd90b9dadfe3706ed31415d559a7"},
+    {file = "langsmith-0.1.100.tar.gz", hash = "sha256:20ff0126253a5a1d621635a3bc44ccacc036e855f52185ae983420f14eb6c605"},
 ]
 
 [package.dependencies]
-pydantic = ">=1,<3"
+httpx = ">=0.23.0,<1"
+orjson = ">=3.9.14,<4.0.0"
+pydantic = {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""}
 requests = ">=2,<3"
 
 [[package]]
@@ -2620,7 +3041,6 @@ description = "Clang Python Bindings, mirrored from the official LLVM repo: http
 optional = false
 python-versions = "*"
 files = [
-    {file = "libclang-18.1.1-1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a"},
     {file = "libclang-18.1.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6f14c3f194704e5d09769108f03185fce7acaf1d1ae4bbb2f30a72c2400cb7c5"},
     {file = "libclang-18.1.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:83ce5045d101b669ac38e6da8e58765f12da2d3aafb3b9b98d88b286a60964d8"},
     {file = "libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl", hash = "sha256:c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b"},
@@ -2633,6 +3053,34 @@ files = [
 ]
 
 [[package]]
+name = "litellm"
+version = "1.43.19"
+description = "Library to easily interface with LLM API providers"
+optional = false
+python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
+files = [
+    {file = "litellm-1.43.19-py3-none-any.whl", hash = "sha256:f66bfe9c8b91577af57a5d1203728abc9b59df38a545148b7e85dec903185c12"},
+    {file = "litellm-1.43.19.tar.gz", hash = "sha256:b1f475f98073632f0cea6d814bb10b14b6498e5ff93b91b52dfc00445bf013ab"},
+]
+
+[package.dependencies]
+aiohttp = "*"
+click = "*"
+importlib-metadata = ">=6.8.0"
+jinja2 = ">=3.1.2,<4.0.0"
+jsonschema = ">=4.22.0,<5.0.0"
+openai = ">=1.40.0"
+pydantic = ">=2.0.0,<3.0.0"
+python-dotenv = ">=0.2.0"
+requests = ">=2.31.0,<3.0.0"
+tiktoken = ">=0.7.0"
+tokenizers = "*"
+
+[package.extras]
+extra-proxy = ["azure-identity (>=1.15.0,<2.0.0)", "azure-keyvault-secrets (>=4.8.0,<5.0.0)", "google-cloud-kms (>=2.21.3,<3.0.0)", "prisma (==0.11.0)", "pynacl (>=1.5.0,<2.0.0)", "resend (>=0.8.0,<0.9.0)"]
+proxy = ["PyJWT (>=2.8.0,<3.0.0)", "apscheduler (>=3.10.4,<4.0.0)", "backoff", "cryptography (>=42.0.5,<43.0.0)", "fastapi (>=0.111.0,<0.112.0)", "fastapi-sso (>=0.10.0,<0.11.0)", "gunicorn (>=22.0.0,<23.0.0)", "orjson (>=3.9.7,<4.0.0)", "python-multipart (>=0.0.9,<0.0.10)", "pyyaml (>=6.0.1,<7.0.0)", "rq", "uvicorn (>=0.22.0,<0.23.0)"]
+
+[[package]]
 name = "locket"
 version = "1.0.0"
 description = "File-based locks for Python on Linux and Windows"
@@ -2642,6 +3090,25 @@ files = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
 ]
+
+[[package]]
+name = "mako"
+version = "1.3.5"
+description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Mako-1.3.5-py3-none-any.whl", hash = "sha256:260f1dbc3a519453a9c856dedfe4beb4e50bd5a26d96386cb6c80856556bb91a"},
+    {file = "Mako-1.3.5.tar.gz", hash = "sha256:48dbc20568c1d276a2698b36d968fa76161bf127194907ea6fc594fa81f943bc"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=0.9.2"
+
+[package.extras]
+babel = ["Babel"]
+lingua = ["lingua"]
+testing = ["pytest"]
 
 [[package]]
 name = "marisa-trie"
@@ -2977,7 +3444,6 @@ python-versions = ">=3.7"
 files = [
     {file = "milvus_lite-2.4.7-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:c828190118b104b05b8c8e0b5a4147811c86b54b8fb67bc2e726ad10fc0b544e"},
     {file = "milvus_lite-2.4.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e1537633c39879714fb15082be56a4b97f74c905a6e98e302ec01320561081af"},
-    {file = "milvus_lite-2.4.7-py3-none-manylinux2014_aarch64.whl", hash = "sha256:fcb909d38c83f21478ca9cb500c84264f988c69f62715ae9462e966767fb76dd"},
     {file = "milvus_lite-2.4.7-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f016474d663045787dddf1c3aad13b7d8b61fd329220318f858184918143dcbf"},
 ]
 
@@ -3009,12 +3475,95 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.2", markers = "python_version > \"3.9\""},
     {version = ">1.20", markers = "python_version <= \"3.9\""},
+    {version = ">=1.21.2", markers = "python_version > \"3.9\""},
 ]
 
 [package.extras]
 dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
+
+[[package]]
+name = "mlflow"
+version = "2.15.1"
+description = "MLflow is an open source platform for the complete machine learning lifecycle"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mlflow-2.15.1-py3-none-any.whl", hash = "sha256:f998b8ec9df9199284f52e79ea5dd0b2b76b327ed7f060531e44f1ecd197c5d9"},
+    {file = "mlflow-2.15.1.tar.gz", hash = "sha256:88da13f547cedce992d4614a4547f44bcdaf369e893179dd9a8bfa60338011bf"},
+]
+
+[package.dependencies]
+alembic = "<1.10.0 || >1.10.0,<2"
+docker = ">=4.0.0,<8"
+Flask = "<4"
+graphene = "<4"
+gunicorn = {version = "<23", markers = "platform_system != \"Windows\""}
+Jinja2 = [
+    {version = ">=2.11,<4", markers = "platform_system != \"Windows\""},
+    {version = ">=3.0,<4", markers = "platform_system == \"Windows\""},
+]
+markdown = ">=3.3,<4"
+matplotlib = "<4"
+mlflow-skinny = "2.15.1"
+numpy = "<2"
+pandas = "<3"
+pyarrow = ">=4.0.0,<16"
+querystring-parser = "<2"
+scikit-learn = "<2"
+scipy = "<2"
+sqlalchemy = ">=1.4.0,<3"
+waitress = {version = "<4", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+aliyun-oss = ["aliyunstoreplugin"]
+databricks = ["azure-storage-file-datalake (>12)", "boto3 (>1)", "botocore", "google-cloud-storage (>=1.30.0)"]
+extras = ["azureml-core (>=1.2.0)", "boto3", "botocore", "google-cloud-storage (>=1.30.0)", "kubernetes", "mlserver (>=1.2.0,!=1.3.1,<1.4.0)", "mlserver-mlflow (>=1.2.0,!=1.3.1,<1.4.0)", "prometheus-flask-exporter", "pyarrow", "pysftp", "requests-auth-aws-sigv4", "virtualenv"]
+gateway = ["aiohttp (<4)", "boto3 (>=1.28.56,<2)", "fastapi (<1)", "pydantic (>=1.0,<3)", "slowapi (>=0.1.9,<1)", "tiktoken (<1)", "uvicorn[standard] (<1)", "watchfiles (<1)"]
+genai = ["aiohttp (<4)", "boto3 (>=1.28.56,<2)", "fastapi (<1)", "pydantic (>=1.0,<3)", "slowapi (>=0.1.9,<1)", "tiktoken (<1)", "uvicorn[standard] (<1)", "watchfiles (<1)"]
+jfrog = ["mlflow-jfrog-plugin"]
+langchain = ["langchain (>=0.1.0,<=0.2.11)"]
+sqlserver = ["mlflow-dbstore"]
+xethub = ["mlflow-xethub"]
+
+[[package]]
+name = "mlflow-skinny"
+version = "2.15.1"
+description = "MLflow is an open source platform for the complete machine learning lifecycle"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mlflow_skinny-2.15.1-py3-none-any.whl", hash = "sha256:a48c6f56106b104dc7221bad91af75a150b927d15210a41928cc8ecba086470a"},
+    {file = "mlflow_skinny-2.15.1.tar.gz", hash = "sha256:302f49757ffc8bdfc517b06f5252a02634203fec5e5ce95ad876a36af8403907"},
+]
+
+[package.dependencies]
+cachetools = ">=5.0.0,<6"
+click = ">=7.0,<9"
+cloudpickle = "<4"
+databricks-sdk = ">=0.20.0,<1"
+entrypoints = "<1"
+gitpython = ">=3.1.9,<4"
+importlib-metadata = ">=3.7.0,<4.7.0 || >4.7.0,<8"
+opentelemetry-api = ">=1.9.0,<3"
+opentelemetry-sdk = ">=1.9.0,<3"
+packaging = "<25"
+protobuf = ">=3.12.0,<6"
+pytz = "<2025"
+pyyaml = ">=5.1,<7"
+requests = ">=2.17.3,<3"
+sqlparse = ">=0.4.0,<1"
+
+[package.extras]
+aliyun-oss = ["aliyunstoreplugin"]
+databricks = ["azure-storage-file-datalake (>12)", "boto3 (>1)", "botocore", "google-cloud-storage (>=1.30.0)"]
+extras = ["azureml-core (>=1.2.0)", "boto3", "botocore", "google-cloud-storage (>=1.30.0)", "kubernetes", "mlserver (>=1.2.0,!=1.3.1,<1.4.0)", "mlserver-mlflow (>=1.2.0,!=1.3.1,<1.4.0)", "prometheus-flask-exporter", "pyarrow", "pysftp", "requests-auth-aws-sigv4", "virtualenv"]
+gateway = ["aiohttp (<4)", "boto3 (>=1.28.56,<2)", "fastapi (<1)", "pydantic (>=1.0,<3)", "slowapi (>=0.1.9,<1)", "tiktoken (<1)", "uvicorn[standard] (<1)", "watchfiles (<1)"]
+genai = ["aiohttp (<4)", "boto3 (>=1.28.56,<2)", "fastapi (<1)", "pydantic (>=1.0,<3)", "slowapi (>=0.1.9,<1)", "tiktoken (<1)", "uvicorn[standard] (<1)", "watchfiles (<1)"]
+jfrog = ["mlflow-jfrog-plugin"]
+langchain = ["langchain (>=0.1.0,<=0.2.11)"]
+sqlserver = ["mlflow-dbstore"]
+xethub = ["mlflow-xethub"]
 
 [[package]]
 name = "msgpack"
@@ -3253,35 +3802,6 @@ test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
 name = "numpy"
-version = "1.22.3"
-description = "NumPy is the fundamental package for array computing with Python."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
-    {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
-    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
-    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
-    {file = "numpy-1.22.3-cp310-cp310-win32.whl", hash = "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430"},
-    {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
-    {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
-    {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
-    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:568dfd16224abddafb1cbcce2ff14f522abe037268514dd7e42c6776a1c3f8e5"},
-    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ca688e1b9b95d80250bca34b11a05e389b1420d00e87a0d12dc45f131f704a1"},
-    {file = "numpy-1.22.3-cp38-cp38-win32.whl", hash = "sha256:e7927a589df200c5e23c57970bafbd0cd322459aa7b1ff73b7c2e84d6e3eae62"},
-    {file = "numpy-1.22.3-cp38-cp38-win_amd64.whl", hash = "sha256:07a8c89a04997625236c5ecb7afe35a02af3896c8aa01890a849913a2309c676"},
-    {file = "numpy-1.22.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123"},
-    {file = "numpy-1.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802"},
-    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bfb1bb598e8229c2d5d48db1860bcf4311337864ea3efdbe1171fb0c5da515d"},
-    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168"},
-    {file = "numpy-1.22.3-cp39-cp39-win32.whl", hash = "sha256:fdf3c08bce27132395d3c3ba1503cac12e17282358cb4bddc25cc46b0aca07aa"},
-    {file = "numpy-1.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:639b54cdf6aa4f82fe37ebf70401bbb74b8508fddcf4797f9fe59615b8c5813a"},
-    {file = "numpy-1.22.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34ea7e9d13a70bf2ab64a2532fe149a9aced424cd05a2c4ba662fd989e3e45f"},
-    {file = "numpy-1.22.3.zip", hash = "sha256:dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18"},
-]
-
-[[package]]
-name = "numpy"
 version = "1.23.5"
 description = "NumPy is the fundamental package for array computing with Python."
 optional = false
@@ -3335,25 +3855,41 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "openai"
-version = "0.28.1"
-description = "Python client library for the OpenAI API"
+version = "1.40.8"
+description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-0.28.1-py3-none-any.whl", hash = "sha256:d18690f9e3d31eedb66b57b88c2165d760b24ea0a01f150dd3f068155088ce68"},
-    {file = "openai-0.28.1.tar.gz", hash = "sha256:4be1dad329a65b4ce1a660fe6d5431b438f429b5855c883435f0f7fcb6d2dcc8"},
+    {file = "openai-1.40.8-py3-none-any.whl", hash = "sha256:3ed4ddad48e0dde059c9b4d3dc240e47781beca2811e52ba449ddc4a471a2fd4"},
+    {file = "openai-1.40.8.tar.gz", hash = "sha256:e225f830b946378e214c5b2cfa8df28ba2aeb7e9d44f738cb2a926fd971f5bc0"},
 ]
 
 [package.dependencies]
-aiohttp = "*"
-requests = ">=2.20"
-tqdm = "*"
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+tqdm = ">4"
+typing-extensions = ">=4.11,<5"
 
 [package.extras]
-datalib = ["numpy", "openpyxl (>=3.0.7)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
-dev = ["black (>=21.6b0,<22.0)", "pytest (==6.*)", "pytest-asyncio", "pytest-mock"]
-embeddings = ["matplotlib", "numpy", "openpyxl (>=3.0.7)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)", "plotly", "scikit-learn (>=1.0.2)", "scipy", "tenacity (>=8.0.1)"]
-wandb = ["numpy", "openpyxl (>=3.0.7)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)", "wandb"]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
+    {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
+]
+
+[package.dependencies]
+et-xmlfile = "*"
 
 [[package]]
 name = "opentelemetry-api"
@@ -3538,18 +4074,81 @@ docs = ["numpydoc", "sphinx (==1.2.3)", "sphinx-rtd-theme", "sphinxcontrib-napol
 tests = ["pytest", "pytest-cov", "pytest-pep8"]
 
 [[package]]
-name = "packaging"
-version = "21.3"
-description = "Core utilities for Python packages"
+name = "orjson"
+version = "3.10.7"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+    {file = "orjson-3.10.7-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:74f4544f5a6405b90da8ea724d15ac9c36da4d72a738c64685003337401f5c12"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34a566f22c28222b08875b18b0dfbf8a947e69df21a9ed5c51a6bf91cfb944ac"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf6ba8ebc8ef5792e2337fb0419f8009729335bb400ece005606336b7fd7bab7"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac7cf6222b29fbda9e3a472b41e6a5538b48f2c8f99261eecd60aafbdb60690c"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:de817e2f5fc75a9e7dd350c4b0f54617b280e26d1631811a43e7e968fa71e3e9"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:348bdd16b32556cf8d7257b17cf2bdb7ab7976af4af41ebe79f9796c218f7e91"},
+    {file = "orjson-3.10.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:479fd0844ddc3ca77e0fd99644c7fe2de8e8be1efcd57705b5c92e5186e8a250"},
+    {file = "orjson-3.10.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fdf5197a21dd660cf19dfd2a3ce79574588f8f5e2dbf21bda9ee2d2b46924d84"},
+    {file = "orjson-3.10.7-cp310-none-win32.whl", hash = "sha256:d374d36726746c81a49f3ff8daa2898dccab6596864ebe43d50733275c629175"},
+    {file = "orjson-3.10.7-cp310-none-win_amd64.whl", hash = "sha256:cb61938aec8b0ffb6eef484d480188a1777e67b05d58e41b435c74b9d84e0b9c"},
+    {file = "orjson-3.10.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:7db8539039698ddfb9a524b4dd19508256107568cdad24f3682d5773e60504a2"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:480f455222cb7a1dea35c57a67578848537d2602b46c464472c995297117fa09"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8a9c9b168b3a19e37fe2778c0003359f07822c90fdff8f98d9d2a91b3144d8e0"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8de062de550f63185e4c1c54151bdddfc5625e37daf0aa1e75d2a1293e3b7d9a"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6b0dd04483499d1de9c8f6203f8975caf17a6000b9c0c54630cef02e44ee624e"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b58d3795dafa334fc8fd46f7c5dc013e6ad06fd5b9a4cc98cb1456e7d3558bd6"},
+    {file = "orjson-3.10.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:33cfb96c24034a878d83d1a9415799a73dc77480e6c40417e5dda0710d559ee6"},
+    {file = "orjson-3.10.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e724cebe1fadc2b23c6f7415bad5ee6239e00a69f30ee423f319c6af70e2a5c0"},
+    {file = "orjson-3.10.7-cp311-none-win32.whl", hash = "sha256:82763b46053727a7168d29c772ed5c870fdae2f61aa8a25994c7984a19b1021f"},
+    {file = "orjson-3.10.7-cp311-none-win_amd64.whl", hash = "sha256:eb8d384a24778abf29afb8e41d68fdd9a156cf6e5390c04cc07bbc24b89e98b5"},
+    {file = "orjson-3.10.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:44a96f2d4c3af51bfac6bc4ef7b182aa33f2f054fd7f34cc0ee9a320d051d41f"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76ac14cd57df0572453543f8f2575e2d01ae9e790c21f57627803f5e79b0d3c3"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bdbb61dcc365dd9be94e8f7df91975edc9364d6a78c8f7adb69c1cdff318ec93"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b48b3db6bb6e0a08fa8c83b47bc169623f801e5cc4f24442ab2b6617da3b5313"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23820a1563a1d386414fef15c249040042b8e5d07b40ab3fe3efbfbbcbcb8864"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0c6a008e91d10a2564edbb6ee5069a9e66df3fbe11c9a005cb411f441fd2c09"},
+    {file = "orjson-3.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d352ee8ac1926d6193f602cbe36b1643bbd1bbcb25e3c1a657a4390f3000c9a5"},
+    {file = "orjson-3.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d2d9f990623f15c0ae7ac608103c33dfe1486d2ed974ac3f40b693bad1a22a7b"},
+    {file = "orjson-3.10.7-cp312-none-win32.whl", hash = "sha256:7c4c17f8157bd520cdb7195f75ddbd31671997cbe10aee559c2d613592e7d7eb"},
+    {file = "orjson-3.10.7-cp312-none-win_amd64.whl", hash = "sha256:1d9c0e733e02ada3ed6098a10a8ee0052dd55774de3d9110d29868d24b17faa1"},
+    {file = "orjson-3.10.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:77d325ed866876c0fa6492598ec01fe30e803272a6e8b10e992288b009cbe149"},
+    {file = "orjson-3.10.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ea2c232deedcb605e853ae1db2cc94f7390ac776743b699b50b071b02bea6fe"},
+    {file = "orjson-3.10.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3dcfbede6737fdbef3ce9c37af3fb6142e8e1ebc10336daa05872bfb1d87839c"},
+    {file = "orjson-3.10.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:11748c135f281203f4ee695b7f80bb1358a82a63905f9f0b794769483ea854ad"},
+    {file = "orjson-3.10.7-cp313-none-win32.whl", hash = "sha256:a7e19150d215c7a13f39eb787d84db274298d3f83d85463e61d277bbd7f401d2"},
+    {file = "orjson-3.10.7-cp313-none-win_amd64.whl", hash = "sha256:eef44224729e9525d5261cc8d28d6b11cafc90e6bd0be2157bde69a52ec83024"},
+    {file = "orjson-3.10.7-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:6ea2b2258eff652c82652d5e0f02bd5e0463a6a52abb78e49ac288827aaa1469"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:430ee4d85841e1483d487e7b81401785a5dfd69db5de01314538f31f8fbf7ee1"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4b6146e439af4c2472c56f8540d799a67a81226e11992008cb47e1267a9b3225"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:084e537806b458911137f76097e53ce7bf5806dda33ddf6aaa66a028f8d43a23"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4829cf2195838e3f93b70fd3b4292156fc5e097aac3739859ac0dcc722b27ac0"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1193b2416cbad1a769f868b1749535d5da47626ac29445803dae7cc64b3f5c98"},
+    {file = "orjson-3.10.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:4e6c3da13e5a57e4b3dca2de059f243ebec705857522f188f0180ae88badd354"},
+    {file = "orjson-3.10.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:c31008598424dfbe52ce8c5b47e0752dca918a4fdc4a2a32004efd9fab41d866"},
+    {file = "orjson-3.10.7-cp38-none-win32.whl", hash = "sha256:7122a99831f9e7fe977dc45784d3b2edc821c172d545e6420c375e5a935f5a1c"},
+    {file = "orjson-3.10.7-cp38-none-win_amd64.whl", hash = "sha256:a763bc0e58504cc803739e7df040685816145a6f3c8a589787084b54ebc9f16e"},
+    {file = "orjson-3.10.7-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e76be12658a6fa376fcd331b1ea4e58f5a06fd0220653450f0d415b8fd0fbe20"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed350d6978d28b92939bfeb1a0570c523f6170efc3f0a0ef1f1df287cd4f4960"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:144888c76f8520e39bfa121b31fd637e18d4cc2f115727865fdf9fa325b10412"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09b2d92fd95ad2402188cf51573acde57eb269eddabaa60f69ea0d733e789fe9"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b24a579123fa884f3a3caadaed7b75eb5715ee2b17ab5c66ac97d29b18fe57f"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591bcfe7512353bd609875ab38050efe3d55e18934e2f18950c108334b4ff"},
+    {file = "orjson-3.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f4db56635b58cd1a200b0a23744ff44206ee6aa428185e2b6c4a65b3197abdcd"},
+    {file = "orjson-3.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0fa5886854673222618638c6df7718ea7fe2f3f2384c452c9ccedc70b4a510a5"},
+    {file = "orjson-3.10.7-cp39-none-win32.whl", hash = "sha256:8272527d08450ab16eb405f47e0f4ef0e5ff5981c3d82afe0efd25dcbef2bcd2"},
+    {file = "orjson-3.10.7-cp39-none-win_amd64.whl", hash = "sha256:974683d4618c0c7dbf4f69c95a979734bf183d0658611760017f6e70a145af58"},
+    {file = "orjson-3.10.7.tar.gz", hash = "sha256:75ef0640403f945f3a1f9f6400686560dbfb0fb5b16589ad62cd477043c4eee3"},
 ]
 
-[package.dependencies]
-pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+[[package]]
+name = "packaging"
+version = "23.2"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+]
 
 [[package]]
 name = "pamqp"
@@ -3602,8 +4201,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3885,16 +4484,20 @@ transformers = ["torch", "transformers"]
 
 [[package]]
 name = "presidio-anonymizer"
-version = "2.2.33"
-description = "Persidio Anonymizer package - replaces analyzed text with desired values."
+version = "2.2.355"
+description = "Presidio Anonymizer package - replaces analyzed text with desired values."
 optional = false
-python-versions = ">=3.5"
+python-versions = "<4.0,>=3.8"
 files = [
-    {file = "presidio_anonymizer-2.2.33-py3-none-any.whl", hash = "sha256:d1e7feff5ff2bc0eed13425356bce19e8e5ffda1f733d5d603b282ccfbe742d0"},
+    {file = "presidio_anonymizer-2.2.355-py3-none-any.whl", hash = "sha256:c85f5f155fcb66aff8e962fcf3984552a5512ab34bb1a433b1a52193e635c23f"},
 ]
 
 [package.dependencies]
+azure-core = "*"
 pycryptodome = ">=3.10.1"
+
+[package.extras]
+server = ["flask (>=1.1)"]
 
 [[package]]
 name = "prompt-toolkit"
@@ -3991,6 +4594,7 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win32.whl", hash = "sha256:dc4926288b2a3e9fd7b50dc6a1909a13bbdadfc67d93f3374d984e56f885579d"},
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:b76bedd166805480ab069612119ea636f5ab8f8771e640ae103e05a4aae3e417"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8532fd6e6e2dc57bcb3bc90b079c60de896d2128c5d9d6f24a63875a95a088cf"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0605eaed3eb239e87df0d5e3c6489daae3f7388d455d0c0b4df899519c6a38d"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f8544b092a29a6ddd72f3556a9fcf249ec412e10ad28be6a0c0d948924f2212"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d423c8d8a3c82d08fe8af900ad5b613ce3632a1249fd6a223941d0735fce493"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e5afae772c00980525f6d6ecf7cbca55676296b580c0e6abb407f15f3706996"},
@@ -3999,6 +4603,8 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:cb16c65dcb648d0a43a2521f2f0a2300f40639f6f8c1ecbc662141e4e3e1ee07"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:911dda9c487075abd54e644ccdf5e5c16773470a6a5d3826fda76699410066fb"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:57fede879f08d23c85140a360c6a77709113efd1c993923c59fde17aa27599fe"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-win32.whl", hash = "sha256:64cf30263844fa208851ebb13b0732ce674d8ec6a0c86a4e160495d299ba3c93"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:81ff62668af011f9a48787564ab7eded4e9fb17a4a6a74af5ffa6a457400d2ab"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2293b001e319ab0d869d660a704942c9e2cce19745262a8aba2115ef41a0a42a"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03ef7df18daf2c4c07e2695e8cfd5ee7f748a1d54d802330985a78d2a5a6dca9"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a602ea5aff39bb9fac6308e9c9d82b9a35c2bf288e184a816002c9fae930b77"},
@@ -4035,6 +4641,54 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp39-cp39-win32.whl", hash = "sha256:9dba73be7305b399924709b91682299794887cbbd88e38226ed9f6712eabee90"},
     {file = "psycopg2_binary-2.9.9-cp39-cp39-win_amd64.whl", hash = "sha256:f7ae5d65ccfbebdfa761585228eb4d0df3a8b15cfb53bd953e713e09fbb12957"},
 ]
+
+[[package]]
+name = "pyarrow"
+version = "15.0.2"
+description = "Python library for Apache Arrow"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyarrow-15.0.2-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:88b340f0a1d05b5ccc3d2d986279045655b1fe8e41aba6ca44ea28da0d1455d8"},
+    {file = "pyarrow-15.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eaa8f96cecf32da508e6c7f69bb8401f03745c050c1dd42ec2596f2e98deecac"},
+    {file = "pyarrow-15.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23c6753ed4f6adb8461e7c383e418391b8d8453c5d67e17f416c3a5d5709afbd"},
+    {file = "pyarrow-15.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f639c059035011db8c0497e541a8a45d98a58dbe34dc8fadd0ef128f2cee46e5"},
+    {file = "pyarrow-15.0.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:290e36a59a0993e9a5224ed2fb3e53375770f07379a0ea03ee2fce2e6d30b423"},
+    {file = "pyarrow-15.0.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:06c2bb2a98bc792f040bef31ad3e9be6a63d0cb39189227c08a7d955db96816e"},
+    {file = "pyarrow-15.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:f7a197f3670606a960ddc12adbe8075cea5f707ad7bf0dffa09637fdbb89f76c"},
+    {file = "pyarrow-15.0.2-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:5f8bc839ea36b1f99984c78e06e7a06054693dc2af8920f6fb416b5bca9944e4"},
+    {file = "pyarrow-15.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5e81dfb4e519baa6b4c80410421528c214427e77ca0ea9461eb4097c328fa33"},
+    {file = "pyarrow-15.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a4f240852b302a7af4646c8bfe9950c4691a419847001178662a98915fd7ee7"},
+    {file = "pyarrow-15.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e7d9cfb5a1e648e172428c7a42b744610956f3b70f524aa3a6c02a448ba853e"},
+    {file = "pyarrow-15.0.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2d4f905209de70c0eb5b2de6763104d5a9a37430f137678edfb9a675bac9cd98"},
+    {file = "pyarrow-15.0.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:90adb99e8ce5f36fbecbbc422e7dcbcbed07d985eed6062e459e23f9e71fd197"},
+    {file = "pyarrow-15.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:b116e7fd7889294cbd24eb90cd9bdd3850be3738d61297855a71ac3b8124ee38"},
+    {file = "pyarrow-15.0.2-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:25335e6f1f07fdaa026a61c758ee7d19ce824a866b27bba744348fa73bb5a440"},
+    {file = "pyarrow-15.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:90f19e976d9c3d8e73c80be84ddbe2f830b6304e4c576349d9360e335cd627fc"},
+    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a22366249bf5fd40ddacc4f03cd3160f2d7c247692945afb1899bab8a140ddfb"},
+    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2a335198f886b07e4b5ea16d08ee06557e07db54a8400cc0d03c7f6a22f785f"},
+    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3e6d459c0c22f0b9c810a3917a1de3ee704b021a5fb8b3bacf968eece6df098f"},
+    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:033b7cad32198754d93465dcfb71d0ba7cb7cd5c9afd7052cab7214676eec38b"},
+    {file = "pyarrow-15.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:29850d050379d6e8b5a693098f4de7fd6a2bea4365bfd073d7c57c57b95041ee"},
+    {file = "pyarrow-15.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:7167107d7fb6dcadb375b4b691b7e316f4368f39f6f45405a05535d7ad5e5058"},
+    {file = "pyarrow-15.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e85241b44cc3d365ef950432a1b3bd44ac54626f37b2e3a0cc89c20e45dfd8bf"},
+    {file = "pyarrow-15.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:248723e4ed3255fcd73edcecc209744d58a9ca852e4cf3d2577811b6d4b59818"},
+    {file = "pyarrow-15.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ff3bdfe6f1b81ca5b73b70a8d482d37a766433823e0c21e22d1d7dde76ca33f"},
+    {file = "pyarrow-15.0.2-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:f3d77463dee7e9f284ef42d341689b459a63ff2e75cee2b9302058d0d98fe142"},
+    {file = "pyarrow-15.0.2-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:8c1faf2482fb89766e79745670cbca04e7018497d85be9242d5350cba21357e1"},
+    {file = "pyarrow-15.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:28f3016958a8e45a1069303a4a4f6a7d4910643fc08adb1e2e4a7ff056272ad3"},
+    {file = "pyarrow-15.0.2-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:89722cb64286ab3d4daf168386f6968c126057b8c7ec3ef96302e81d8cdb8ae4"},
+    {file = "pyarrow-15.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cd0ba387705044b3ac77b1b317165c0498299b08261d8122c96051024f953cd5"},
+    {file = "pyarrow-15.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad2459bf1f22b6a5cdcc27ebfd99307d5526b62d217b984b9f5c974651398832"},
+    {file = "pyarrow-15.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58922e4bfece8b02abf7159f1f53a8f4d9f8e08f2d988109126c17c3bb261f22"},
+    {file = "pyarrow-15.0.2-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:adccc81d3dc0478ea0b498807b39a8d41628fa9210729b2f718b78cb997c7c91"},
+    {file = "pyarrow-15.0.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8bd2baa5fe531571847983f36a30ddbf65261ef23e496862ece83bdceb70420d"},
+    {file = "pyarrow-15.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6669799a1d4ca9da9c7e06ef48368320f5856f36f9a4dd31a11839dda3f6cc8c"},
+    {file = "pyarrow-15.0.2.tar.gz", hash = "sha256:9c9bc803cb3b7bfacc1e96ffbfd923601065d9d3f911179d81e72d99fd74a3d9"},
+]
+
+[package.dependencies]
+numpy = ">=1.16.6,<2"
 
 [[package]]
 name = "pyasn1"
@@ -4670,6 +5324,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -4677,8 +5332,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -4695,6 +5358,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -4702,6 +5366,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -4732,6 +5397,20 @@ fastembed = ["fastembed (==0.2.7)"]
 fastembed-gpu = ["fastembed-gpu (==0.2.7)"]
 
 [[package]]
+name = "querystring-parser"
+version = "1.2.4"
+description = "QueryString parser for Python/Django that correctly handles nested dictionaries"
+optional = false
+python-versions = "*"
+files = [
+    {file = "querystring_parser-1.2.4-py2.py3-none-any.whl", hash = "sha256:d2fa90765eaf0de96c8b087872991a10238e89ba015ae59fedfed6bd61c242a0"},
+    {file = "querystring_parser-1.2.4.tar.gz", hash = "sha256:644fce1cffe0530453b43a83a38094dbe422ccba8c9b2f2a1c00280e14ca8a62"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "questionary"
 version = "2.0.1"
 description = "Python library to build pretty command line user prompts ⭐️"
@@ -4760,13 +5439,13 @@ fire = "*"
 
 [[package]]
 name = "rasa-pro"
-version = "3.9.3"
+version = "3.10.0rc1"
 description = "State-of-the-art open-core Conversational AI framework for Enterprises that natively leverages generative AI for effortless assistant development."
 optional = false
 python-versions = ">=3.8.1,<3.11"
 files = [
-    {file = "rasa_pro-3.9.3-py3-none-any.whl", hash = "sha256:4fbf33e42b3d3bb0b359db4c47339bfd483c566cbc4bc713dd3495984e4b110b"},
-    {file = "rasa_pro-3.9.3.tar.gz", hash = "sha256:f0bed326eb3827313e7add81c2d73cb81218f02c29b2fe710ed53d40f6772f46"},
+    {file = "rasa_pro-3.10.0rc1-py3-none-any.whl", hash = "sha256:99443f0e47a5bf460700c7ad5e5e9b479855fb04627640db03c1466356463fd1"},
+    {file = "rasa_pro-3.10.0rc1.tar.gz", hash = "sha256:eb4406f53530ee0a66f947983134b63abf29edbfc6a428847250c17190011b73"},
 ]
 
 [package.dependencies]
@@ -4777,7 +5456,7 @@ aiohttp = ">=3.9.4,<3.10"
 apscheduler = ">=3.10,<3.11"
 attrs = ">=23.1,<23.2"
 azure-storage-blob = ">=12.16.0,<12.17.0"
-boto3 = ">=1.27.1,<2.0.0"
+boto3 = ">=1.27.1,<1.28.0"
 CacheControl = ">=0.12.14,<0.13.0"
 certifi = ">=2024.2.2"
 cloudpickle = ">=2.2.1,<3.1"
@@ -4789,9 +5468,10 @@ confluent-kafka = ">=2.3.0,<3.0.0"
 cryptography = ">=42.0.5"
 cvg-python-sdk = ">=0.5.1,<0.6.0"
 dask = {version = "2022.10.2", markers = "python_version >= \"3.8\" and python_version < \"3.11\""}
+diskcache = ">=5.6.3,<5.7.0"
 dnspython = "2.6.1"
 faiss-cpu = ">=1.7.4,<2.0.0"
-faker = ">=19.13.0,<20.0.0"
+faker = ">=26.0.0,<27.0.0"
 fbmessenger = ">=6.0.0,<6.1.0"
 google-auth = ">=2.23.4,<3"
 google-cloud-storage = ">=2.14.0,<3.0.0"
@@ -4802,26 +5482,27 @@ jinja2 = ">=3.1.4,<4.0.0"
 joblib = ">=1.2.0,<1.3.0"
 jsonpatch = ">=1.33,<2.0"
 jsonpickle = ">=3.0,<3.1"
-jsonschema = ">=4.20,<4.21"
-langchain = ">=0.0.329,<0.0.330"
+jsonschema = ">=4.22"
+langchain = ">=0.2.0,<0.3.0"
+langchain-community = ">=0.2.0,<0.3.0"
+litellm = ">=1.43.6,<2.0.0"
 matplotlib = ">=3.7,<3.8"
 mattermostwrapper = ">=2.2,<2.3"
+mlflow = {version = ">=2.15.1,<3.0.0", optional = true, markers = "extra == \"mlflow\""}
 networkx = ">=3.1,<3.2"
-numpy = [
-    {version = "1.22.3", markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\" and python_version == \"3.10\""},
-    {version = ">=1.23.5,<1.25.0", markers = "sys_platform != \"win32\" and python_version >= \"3.8\" and python_version < \"3.11\" or platform_python_implementation == \"PyPy\" and python_version >= \"3.8\" and python_version < \"3.11\""},
-]
-openai = ">=0.28.1,<0.29.0"
+numpy = {version = ">=1.23.5,<1.25.0", markers = "python_version >= \"3.8\" and python_version < \"3.11\""}
+openai = ">=1.40.0,<1.41.0"
+openpyxl = ">=3.1.5,<4.0.0"
 opentelemetry-api = ">=1.16.0,<1.17.0"
 opentelemetry-exporter-jaeger = ">=1.16.0,<1.17.0"
 opentelemetry-exporter-otlp = ">=1.16.0,<1.17.0"
 opentelemetry-sdk = ">=1.16.0,<1.17.0"
-packaging = ">=21.3,<21.4"
+packaging = ">=23.2,<23.3"
 pep440-version-utils = ">=1.1.0,<1.2.0"
 pluggy = ">=1.2.0,<2.0.0"
 portalocker = ">=2.7.0,<3.0.0"
 presidio-analyzer = ">=2.2.33,<2.2.34"
-presidio-anonymizer = ">=2.2.33,<2.2.34"
+presidio-anonymizer = ">=2.2.354,<3.0.0"
 prompt-toolkit = ">=3.0.28,<3.0.29"
 protobuf = ">=4.23.3,<4.25.4"
 psutil = ">=5.9.5,<6.0.0"
@@ -4837,14 +5518,14 @@ pypred = ">=0.4.0,<0.5.0"
 python-dateutil = ">=2.8.2,<2.9.0"
 python-dotenv = ">=1.0.1,<2.0.0"
 python-engineio = ">=4.5.1,<5.0.0 || >5.0.0,<6"
-python-keycloak = ">=3.7.0,<4.0.0"
+python-keycloak = ">=3.12.0,<4.0.0"
 python-socketio = ">=5.8,<6"
 pytz = ">=2022.7.1,<2023.0"
 pyyaml = ">=6.0"
 qdrant-client = ">=1.9.0,<2.0.0"
 questionary = ">=1.10.0,<2.1.0"
 randomname = ">=0.2.1,<0.3.0"
-rasa-sdk = "3.9.0"
+rasa-sdk = "3.10.0rc1"
 redis = ">=4.6.0,<6.0"
 regex = ">=2022.10.31,<2022.11"
 requests = ">=2.31.0,<2.32.0"
@@ -4858,7 +5539,7 @@ sanic-routing = ">=22.8.0,<23.0.0"
 scikit-learn = {version = ">=1.1.3,<1.2", markers = "python_version >= \"3.8\" and python_version < \"3.11\""}
 scipy = {version = ">=1.10.1,<1.11.0", markers = "python_version >= \"3.8\" and python_version < \"3.11\""}
 sentry-sdk = ">=1.14.0,<1.15.0"
-setuptools = ">=69.5.1"
+setuptools = ">=70.0.0,<70.1.0"
 sklearn-crfsuite = ">=0.3.6,<0.4.0"
 slack-sdk = ">=3.27.1,<4.0.0"
 SQLAlchemy = ">=2.0.22,<2.1.0"
@@ -4877,7 +5558,7 @@ tensorflow-io-gcs-filesystem = [
 tensorflow-macos = {version = "2.12.0", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
 tensorflow-text = {version = "2.12.0", markers = "sys_platform != \"win32\" and (platform_machine != \"arm64\" and platform_machine != \"aarch64\")"}
 terminaltables = ">=3.1.10,<3.2.0"
-tiktoken = ">=0.4.0,<0.5.0"
+tiktoken = ">=0.7.0,<0.8.0"
 tqdm = ">=4.66.2,<5.0.0"
 twilio = ">=8.4,<8.5"
 types-protobuf = "4.25.0.20240417"
@@ -4893,6 +5574,7 @@ full = ["jieba (>=0.42.1,<0.43)", "sentencepiece[sentencepiece] (>=0.1.99,<0.2.0
 gh-release-notes = ["github3.py (>=3.2.0,<3.3.0)"]
 jieba = ["jieba (>=0.42.1,<0.43)"]
 metal = ["tensorflow-metal (==0.8.0)"]
+mlflow = ["mlflow (>=2.15.1,<3.0.0)"]
 spacy = ["spacy (>=3.5.4,<4.0.0)"]
 transformers = ["sentencepiece[sentencepiece] (>=0.1.99,<0.2.0)", "transformers (>=4.36.2,<4.37.0)"]
 
@@ -4903,18 +5585,19 @@ reference = "rasa-pro"
 
 [[package]]
 name = "rasa-sdk"
-version = "3.9.0"
+version = "3.10.0rc1"
 description = "Open source machine learning framework to automate text- and voice-based conversations: NLU, dialogue management, connect to Slack, Facebook, and more - Create chatbots and voice assistants"
 optional = false
 python-versions = "<3.11,>=3.8"
 files = [
-    {file = "rasa_sdk-3.9.0-py3-none-any.whl", hash = "sha256:c750aca4d62a2e11db245d6c6ea6693929a597b428c76492928e725263e8fd60"},
-    {file = "rasa_sdk-3.9.0.tar.gz", hash = "sha256:b96f5097cb567992f8e35f270d5e3cf867bf674ef94fc159478f84010f49fc59"},
+    {file = "rasa_sdk-3.10.0rc1-py3-none-any.whl", hash = "sha256:05ad3566d8ff2dc3fca392aeeb2f340a211b41b4e08b5f6881aaa4e4464a75db"},
+    {file = "rasa_sdk-3.10.0rc1.tar.gz", hash = "sha256:2b4b85a858481a936dbfffe01e91bcbb94eaec59e751473c84b2ae41987bac9d"},
 ]
 
 [package.dependencies]
 coloredlogs = ">=10,<16"
 grpcio = "1.59.3"
+grpcio-health-checking = "1.59.3"
 grpcio-tools = "1.56.2"
 opentelemetry-api = ">=1.16.0,<1.17.0"
 opentelemetry-exporter-jaeger = ">=1.16.0,<1.17.0"
@@ -5310,37 +5993,51 @@ python-versions = ">=3.6"
 files = [
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d92f81886165cb14d7b067ef37e142256f1c6a90a65cd156b063a43da1708cfd"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b5edda50e5e9e15e54a6a8a0070302b00c518a9d32accc2346ad6c984aacd279"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7048c338b6c86627afb27faecf418768acb6331fc24cfa56c93e8c9780f815fa"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win_amd64.whl", hash = "sha256:1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b"},
     {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3fcc54cb0c8b811ff66082de1680b4b14cf8a81dce0d4fbf665c2265a81e07a1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl", hash = "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:665f58bfd29b167039f714c6998178d27ccd83984084c286110ef26b230f259f"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl", hash = "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9eb5dee2772b0f704ca2e45b1713e4e5198c18f515b52743576d196348f374d3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl", hash = "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"},
     {file = "ruamel.yaml.clib-0.2.8.tar.gz", hash = "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"},
@@ -5348,20 +6045,20 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.10.2"
+version = "0.6.2"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">= 3.7"
 files = [
-    {file = "s3transfer-0.10.2-py3-none-any.whl", hash = "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"},
-    {file = "s3transfer-0.10.2.tar.gz", hash = "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6"},
+    {file = "s3transfer-0.6.2-py3-none-any.whl", hash = "sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084"},
+    {file = "s3transfer-0.6.2.tar.gz", hash = "sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861"},
 ]
 
 [package.dependencies]
-botocore = ">=1.33.2,<2.0a.0"
+botocore = ">=1.12.36,<2.0a.0"
 
 [package.extras]
-crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "sanic"
@@ -5555,18 +6252,18 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "setuptools"
-version = "70.1.1"
+version = "70.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.1.1-py3-none-any.whl", hash = "sha256:a58a8fde0541dab0419750bcc521fbdf8585f6e5cb41909df3a472ef7b81ca95"},
-    {file = "setuptools-70.1.1.tar.gz", hash = "sha256:937a48c7cdb7a21eb53cd7f9b59e525503aa8abaf3584c730dc5f7a5bec3a650"},
+    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
+    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "shellingham"
@@ -5664,6 +6361,17 @@ webhdfs = ["requests"]
 zst = ["zstandard"]
 
 [[package]]
+name = "smmap"
+version = "5.0.1"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "smmap-5.0.1-py3-none-any.whl", hash = "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da"},
+    {file = "smmap-5.0.1.tar.gz", hash = "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -5720,8 +6428,8 @@ jinja2 = "*"
 langcodes = ">=3.2.0,<4.0.0"
 murmurhash = ">=0.28.0,<1.1.0"
 numpy = [
-    {version = ">=1.19.0", markers = "python_version >= \"3.9\""},
     {version = ">=1.15.0", markers = "python_version < \"3.9\""},
+    {version = ">=1.19.0", markers = "python_version >= \"3.9\""},
 ]
 packaging = ">=20.0"
 preshed = ">=3.0.2,<3.1.0"
@@ -5872,6 +6580,21 @@ postgresql-psycopg2cffi = ["psycopg2cffi"]
 postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
 pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.1"
+description = "A non-validating SQL parser."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "sqlparse-0.5.1-py3-none-any.whl", hash = "sha256:773dcbf9a5ab44a090f3441e2180efe2560220203dc2f8c0b0fa141e18b505e4"},
+    {file = "sqlparse-0.5.1.tar.gz", hash = "sha256:bb6b4df465655ef332548e24f08e205afc81b9ab86cb1c45657a7ff173a3a00e"},
+]
+
+[package.extras]
+dev = ["build", "hatch"]
+doc = ["sphinx"]
 
 [[package]]
 name = "srsly"
@@ -6403,8 +7126,8 @@ confection = ">=0.0.1,<1.0.0"
 cymem = ">=2.0.2,<2.1.0"
 murmurhash = ">=1.0.2,<1.1.0"
 numpy = [
-    {version = ">=1.19.0,<2.0.0", markers = "python_version >= \"3.9\""},
     {version = ">=1.15.0,<2.0.0", markers = "python_version < \"3.9\""},
+    {version = ">=1.19.0,<2.0.0", markers = "python_version >= \"3.9\""},
 ]
 packaging = ">=20.0"
 preshed = ">=3.0.2,<3.1.0"
@@ -6469,40 +7192,47 @@ twisted = ["twisted"]
 
 [[package]]
 name = "tiktoken"
-version = "0.4.0"
+version = "0.7.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tiktoken-0.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:176cad7f053d2cc82ce7e2a7c883ccc6971840a4b5276740d0b732a2b2011f8a"},
-    {file = "tiktoken-0.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:450d504892b3ac80207700266ee87c932df8efea54e05cefe8613edc963c1285"},
-    {file = "tiktoken-0.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00d662de1e7986d129139faf15e6a6ee7665ee103440769b8dedf3e7ba6ac37f"},
-    {file = "tiktoken-0.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5727d852ead18b7927b8adf558a6f913a15c7766725b23dbe21d22e243041b28"},
-    {file = "tiktoken-0.4.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c06cd92b09eb0404cedce3702fa866bf0d00e399439dad3f10288ddc31045422"},
-    {file = "tiktoken-0.4.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9ec161e40ed44e4210d3b31e2ff426b4a55e8254f1023e5d2595cb60044f8ea6"},
-    {file = "tiktoken-0.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:1e8fa13cf9889d2c928b9e258e9dbbbf88ab02016e4236aae76e3b4f82dd8288"},
-    {file = "tiktoken-0.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bb2341836b725c60d0ab3c84970b9b5f68d4b733a7bcb80fb25967e5addb9920"},
-    {file = "tiktoken-0.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ca30367ad750ee7d42fe80079d3092bd35bb266be7882b79c3bd159b39a17b0"},
-    {file = "tiktoken-0.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3dc3df19ddec79435bb2a94ee46f4b9560d0299c23520803d851008445671197"},
-    {file = "tiktoken-0.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d980fa066e962ef0f4dad0222e63a484c0c993c7a47c7dafda844ca5aded1f3"},
-    {file = "tiktoken-0.4.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:329f548a821a2f339adc9fbcfd9fc12602e4b3f8598df5593cfc09839e9ae5e4"},
-    {file = "tiktoken-0.4.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b1a038cee487931a5caaef0a2e8520e645508cde21717eacc9af3fbda097d8bb"},
-    {file = "tiktoken-0.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:08efa59468dbe23ed038c28893e2a7158d8c211c3dd07f2bbc9a30e012512f1d"},
-    {file = "tiktoken-0.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f3020350685e009053829c1168703c346fb32c70c57d828ca3742558e94827a9"},
-    {file = "tiktoken-0.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ba16698c42aad8190e746cd82f6a06769ac7edd415d62ba027ea1d99d958ed93"},
-    {file = "tiktoken-0.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c15d9955cc18d0d7ffcc9c03dc51167aedae98542238b54a2e659bd25fe77ed"},
-    {file = "tiktoken-0.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64e1091c7103100d5e2c6ea706f0ec9cd6dc313e6fe7775ef777f40d8c20811e"},
-    {file = "tiktoken-0.4.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e87751b54eb7bca580126353a9cf17a8a8eaadd44edaac0e01123e1513a33281"},
-    {file = "tiktoken-0.4.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e063b988b8ba8b66d6cc2026d937557437e79258095f52eaecfafb18a0a10c03"},
-    {file = "tiktoken-0.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:9c6dd439e878172dc163fced3bc7b19b9ab549c271b257599f55afc3a6a5edef"},
-    {file = "tiktoken-0.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8d1d97f83697ff44466c6bef5d35b6bcdb51e0125829a9c0ed1e6e39fb9a08fb"},
-    {file = "tiktoken-0.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1b6bce7c68aa765f666474c7c11a7aebda3816b58ecafb209afa59c799b0dd2d"},
-    {file = "tiktoken-0.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a73286c35899ca51d8d764bc0b4d60838627ce193acb60cc88aea60bddec4fd"},
-    {file = "tiktoken-0.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0394967d2236a60fd0aacef26646b53636423cc9c70c32f7c5124ebe86f3093"},
-    {file = "tiktoken-0.4.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:dae2af6f03ecba5f679449fa66ed96585b2fa6accb7fd57d9649e9e398a94f44"},
-    {file = "tiktoken-0.4.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:55e251b1da3c293432179cf7c452cfa35562da286786be5a8b1ee3405c2b0dd2"},
-    {file = "tiktoken-0.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:c835d0ee1f84a5aa04921717754eadbc0f0a56cf613f78dfc1cf9ad35f6c3fea"},
-    {file = "tiktoken-0.4.0.tar.gz", hash = "sha256:59b20a819969735b48161ced9b92f05dc4519c17be4015cfb73b65270a243620"},
+    {file = "tiktoken-0.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485f3cc6aba7c6b6ce388ba634fbba656d9ee27f766216f45146beb4ac18b25f"},
+    {file = "tiktoken-0.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e54be9a2cd2f6d6ffa3517b064983fb695c9a9d8aa7d574d1ef3c3f931a99225"},
+    {file = "tiktoken-0.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79383a6e2c654c6040e5f8506f3750db9ddd71b550c724e673203b4f6b4b4590"},
+    {file = "tiktoken-0.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d4511c52caacf3c4981d1ae2df85908bd31853f33d30b345c8b6830763f769c"},
+    {file = "tiktoken-0.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13c94efacdd3de9aff824a788353aa5749c0faee1fbe3816df365ea450b82311"},
+    {file = "tiktoken-0.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8e58c7eb29d2ab35a7a8929cbeea60216a4ccdf42efa8974d8e176d50c9a3df5"},
+    {file = "tiktoken-0.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:21a20c3bd1dd3e55b91c1331bf25f4af522c525e771691adbc9a69336fa7f702"},
+    {file = "tiktoken-0.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:10c7674f81e6e350fcbed7c09a65bca9356eaab27fb2dac65a1e440f2bcfe30f"},
+    {file = "tiktoken-0.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:084cec29713bc9d4189a937f8a35dbdfa785bd1235a34c1124fe2323821ee93f"},
+    {file = "tiktoken-0.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:811229fde1652fedcca7c6dfe76724d0908775b353556d8a71ed74d866f73f7b"},
+    {file = "tiktoken-0.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86b6e7dc2e7ad1b3757e8a24597415bafcfb454cebf9a33a01f2e6ba2e663992"},
+    {file = "tiktoken-0.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1063c5748be36344c7e18c7913c53e2cca116764c2080177e57d62c7ad4576d1"},
+    {file = "tiktoken-0.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20295d21419bfcca092644f7e2f2138ff947a6eb8cfc732c09cc7d76988d4a89"},
+    {file = "tiktoken-0.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:959d993749b083acc57a317cbc643fb85c014d055b2119b739487288f4e5d1cb"},
+    {file = "tiktoken-0.7.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:71c55d066388c55a9c00f61d2c456a6086673ab7dec22dd739c23f77195b1908"},
+    {file = "tiktoken-0.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:09ed925bccaa8043e34c519fbb2f99110bd07c6fd67714793c21ac298e449410"},
+    {file = "tiktoken-0.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03c6c40ff1db0f48a7b4d2dafeae73a5607aacb472fa11f125e7baf9dce73704"},
+    {file = "tiktoken-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d20b5c6af30e621b4aca094ee61777a44118f52d886dbe4f02b70dfe05c15350"},
+    {file = "tiktoken-0.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d427614c3e074004efa2f2411e16c826f9df427d3c70a54725cae860f09e4bf4"},
+    {file = "tiktoken-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8c46d7af7b8c6987fac9b9f61041b452afe92eb087d29c9ce54951280f899a97"},
+    {file = "tiktoken-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:0bc603c30b9e371e7c4c7935aba02af5994a909fc3c0fe66e7004070858d3f8f"},
+    {file = "tiktoken-0.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2398fecd38c921bcd68418675a6d155fad5f5e14c2e92fcf5fe566fa5485a858"},
+    {file = "tiktoken-0.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f5f6afb52fb8a7ea1c811e435e4188f2bef81b5e0f7a8635cc79b0eef0193d6"},
+    {file = "tiktoken-0.7.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:861f9ee616766d736be4147abac500732b505bf7013cfaf019b85892637f235e"},
+    {file = "tiktoken-0.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54031f95c6939f6b78122c0aa03a93273a96365103793a22e1793ee86da31685"},
+    {file = "tiktoken-0.7.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:fffdcb319b614cf14f04d02a52e26b1d1ae14a570f90e9b55461a72672f7b13d"},
+    {file = "tiktoken-0.7.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:c72baaeaefa03ff9ba9688624143c858d1f6b755bb85d456d59e529e17234769"},
+    {file = "tiktoken-0.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:131b8aeb043a8f112aad9f46011dced25d62629091e51d9dc1adbf4a1cc6aa98"},
+    {file = "tiktoken-0.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cabc6dc77460df44ec5b879e68692c63551ae4fae7460dd4ff17181df75f1db7"},
+    {file = "tiktoken-0.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8d57f29171255f74c0aeacd0651e29aa47dff6f070cb9f35ebc14c82278f3b25"},
+    {file = "tiktoken-0.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ee92776fdbb3efa02a83f968c19d4997a55c8e9ce7be821ceee04a1d1ee149c"},
+    {file = "tiktoken-0.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e215292e99cb41fbc96988ef62ea63bb0ce1e15f2c147a61acc319f8b4cbe5bf"},
+    {file = "tiktoken-0.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8a81bac94769cab437dd3ab0b8a4bc4e0f9cf6835bcaa88de71f39af1791727a"},
+    {file = "tiktoken-0.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d6d73ea93e91d5ca771256dfc9d1d29f5a554b83821a1dc0891987636e0ae226"},
+    {file = "tiktoken-0.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:2bcb28ddf79ffa424f171dfeef9a4daff61a94c631ca6813f43967cb263b83b9"},
+    {file = "tiktoken-0.7.0.tar.gz", hash = "sha256:1077266e949c24e0291f6c350433c6f0971365ece2b173a23bc3b9f9defef6b6"},
 ]
 
 [package.dependencies]
@@ -6532,6 +7262,123 @@ requests-file = ">=1.4"
 [package.extras]
 release = ["build", "twine"]
 testing = ["black", "mypy", "pytest", "pytest-gitignore", "pytest-mock", "responses", "ruff", "syrupy", "tox", "types-filelock", "types-requests"]
+
+[[package]]
+name = "tokenizers"
+version = "0.20.0"
+description = ""
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tokenizers-0.20.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:6cff5c5e37c41bc5faa519d6f3df0679e4b37da54ea1f42121719c5e2b4905c0"},
+    {file = "tokenizers-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:62a56bf75c27443432456f4ca5ca055befa95e25be8a28141cc495cac8ae4d6d"},
+    {file = "tokenizers-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68cc7de6a63f09c4a86909c2597b995aa66e19df852a23aea894929c74369929"},
+    {file = "tokenizers-0.20.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:053c37ecee482cc958fdee53af3c6534286a86f5d35aac476f7c246830e53ae5"},
+    {file = "tokenizers-0.20.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3d7074aaabc151a6363fa03db5493fc95b423b2a1874456783989e96d541c7b6"},
+    {file = "tokenizers-0.20.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a11435780f2acd89e8fefe5e81cecf01776f6edb9b3ac95bcb76baee76b30b90"},
+    {file = "tokenizers-0.20.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9a81cd2712973b007d84268d45fc3f6f90a79c31dfe7f1925e6732f8d2959987"},
+    {file = "tokenizers-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7dfd796ab9d909f76fb93080e1c7c8309f196ecb316eb130718cd5e34231c69"},
+    {file = "tokenizers-0.20.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8029ad2aa8cb00605c9374566034c1cc1b15130713e0eb5afcef6cface8255c9"},
+    {file = "tokenizers-0.20.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ca4d54260ebe97d59dfa9a30baa20d0c4dd9137d99a8801700055c561145c24e"},
+    {file = "tokenizers-0.20.0-cp310-none-win32.whl", hash = "sha256:95ee16b57cec11b86a7940174ec5197d506439b0f415ab3859f254b1dffe9df0"},
+    {file = "tokenizers-0.20.0-cp310-none-win_amd64.whl", hash = "sha256:0a61a11e93eeadbf02aea082ffc75241c4198e0608bbbac4f65a9026851dcf37"},
+    {file = "tokenizers-0.20.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6636b798b3c4d6c9b1af1a918bd07c867808e5a21c64324e95318a237e6366c3"},
+    {file = "tokenizers-0.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ec603e42eaf499ffd58b9258162add948717cf21372458132f14e13a6bc7172"},
+    {file = "tokenizers-0.20.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cce124264903a8ea6f8f48e1cc7669e5ef638c18bd4ab0a88769d5f92debdf7f"},
+    {file = "tokenizers-0.20.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07bbeba0231cf8de07aa6b9e33e9779ff103d47042eeeb859a8c432e3292fb98"},
+    {file = "tokenizers-0.20.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:06c0ca8397b35d38b83a44a9c6929790c1692957d88541df061cb34d82ebbf08"},
+    {file = "tokenizers-0.20.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ca6557ac3b83d912dfbb1f70ab56bd4b0594043916688e906ede09f42e192401"},
+    {file = "tokenizers-0.20.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2a5ad94c9e80ac6098328bee2e3264dbced4c6faa34429994d473f795ec58ef4"},
+    {file = "tokenizers-0.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b5c7f906ee6bec30a9dc20268a8b80f3b9584de1c9f051671cb057dc6ce28f6"},
+    {file = "tokenizers-0.20.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:31e087e9ee1b8f075b002bfee257e858dc695f955b43903e1bb4aa9f170e37fe"},
+    {file = "tokenizers-0.20.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c3124fb6f3346cb3d8d775375d3b429bf4dcfc24f739822702009d20a4297990"},
+    {file = "tokenizers-0.20.0-cp311-none-win32.whl", hash = "sha256:a4bb8b40ba9eefa621fdcabf04a74aa6038ae3be0c614c6458bd91a4697a452f"},
+    {file = "tokenizers-0.20.0-cp311-none-win_amd64.whl", hash = "sha256:2b709d371f1fe60a28ef0c5c67815952d455ca7f34dbe7197eaaed3cc54b658e"},
+    {file = "tokenizers-0.20.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:15c81a17d0d66f4987c6ca16f4bea7ec253b8c7ed1bb00fdc5d038b1bb56e714"},
+    {file = "tokenizers-0.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6a531cdf1fb6dc41c984c785a3b299cb0586de0b35683842a3afbb1e5207f910"},
+    {file = "tokenizers-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06caabeb4587f8404e0cd9d40f458e9cba3e815c8155a38e579a74ff3e2a4301"},
+    {file = "tokenizers-0.20.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8768f964f23f5b9f50546c0369c75ab3262de926983888bbe8b98be05392a79c"},
+    {file = "tokenizers-0.20.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:626403860152c816f97b649fd279bd622c3d417678c93b4b1a8909b6380b69a8"},
+    {file = "tokenizers-0.20.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c1b88fa9e5ff062326f4bf82681da5a96fca7104d921a6bd7b1e6fcf224af26"},
+    {file = "tokenizers-0.20.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d7e559436a07dc547f22ce1101f26d8b2fad387e28ec8e7e1e3b11695d681d8"},
+    {file = "tokenizers-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e48afb75e50449848964e4a67b0da01261dd3aa8df8daecf10db8fd7f5b076eb"},
+    {file = "tokenizers-0.20.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:baf5d0e1ff44710a95eefc196dd87666ffc609fd447c5e5b68272a7c3d342a1d"},
+    {file = "tokenizers-0.20.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e5e56df0e8ed23ba60ae3848c3f069a0710c4b197218fe4f89e27eba38510768"},
+    {file = "tokenizers-0.20.0-cp312-none-win32.whl", hash = "sha256:ec53e5ecc142a82432f9c6c677dbbe5a2bfee92b8abf409a9ecb0d425ee0ce75"},
+    {file = "tokenizers-0.20.0-cp312-none-win_amd64.whl", hash = "sha256:f18661ece72e39c0dfaa174d6223248a15b457dbd4b0fc07809b8e6d3ca1a234"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-macosx_10_12_x86_64.whl", hash = "sha256:f7065b1084d8d1a03dc89d9aad69bcbc8415d4bc123c367063eb32958cd85054"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:e5d4069e4714e3f7ba0a4d3d44f9d84a432cd4e4aa85c3d7dd1f51440f12e4a1"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:799b808529e54b7e1a36350bda2aeb470e8390e484d3e98c10395cee61d4e3c6"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f9baa027cc8a281ad5f7725a93c204d7a46986f88edbe8ef7357f40a23fb9c7"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:010ec7f3f7a96adc4c2a34a3ada41fa14b4b936b5628b4ff7b33791258646c6b"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:98d88f06155335b14fd78e32ee28ca5b2eb30fced4614e06eb14ae5f7fba24ed"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e13eb000ef540c2280758d1b9cfa5fe424b0424ae4458f440e6340a4f18b2638"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fab3cf066ff426f7e6d70435dc28a9ff01b2747be83810e397cba106f39430b0"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:39fa3761b30a89368f322e5daf4130dce8495b79ad831f370449cdacfb0c0d37"},
+    {file = "tokenizers-0.20.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c8da0fba4d179ddf2607821575998df3c294aa59aa8df5a6646dc64bc7352bce"},
+    {file = "tokenizers-0.20.0-cp37-none-win32.whl", hash = "sha256:fada996d6da8cf213f6e3c91c12297ad4f6cdf7a85c2fadcd05ec32fa6846fcd"},
+    {file = "tokenizers-0.20.0-cp37-none-win_amd64.whl", hash = "sha256:7d29aad702279e0760c265fcae832e89349078e3418dd329732d4503259fd6bd"},
+    {file = "tokenizers-0.20.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:099c68207f3ef0227ecb6f80ab98ea74de559f7b124adc7b17778af0250ee90a"},
+    {file = "tokenizers-0.20.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:68012d8a8cddb2eab3880870d7e2086cb359c7f7a2b03f5795044f5abff4e850"},
+    {file = "tokenizers-0.20.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9253bdd209c6aee168deca7d0e780581bf303e0058f268f9bb06859379de19b6"},
+    {file = "tokenizers-0.20.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f868600ddbcb0545905ed075eb7218a0756bf6c09dae7528ea2f8436ebd2c93"},
+    {file = "tokenizers-0.20.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a9643d9c8c5f99b6aba43fd10034f77cc6c22c31f496d2f0ee183047d948fa0"},
+    {file = "tokenizers-0.20.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c375c6a889aeab44734028bc65cc070acf93ccb0f9368be42b67a98e1063d3f6"},
+    {file = "tokenizers-0.20.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e359f852328e254f070bbd09a19a568421d23388f04aad9f2fb7da7704c7228d"},
+    {file = "tokenizers-0.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d98b01a309d4387f3b1c1dd68a8b8136af50376cf146c1b7e8d8ead217a5be4b"},
+    {file = "tokenizers-0.20.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:459f7537119554c2899067dec1ac74a00d02beef6558f4ee2e99513bf6d568af"},
+    {file = "tokenizers-0.20.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:392b87ec89452628c045c9f2a88bc2a827f4c79e7d84bc3b72752b74c2581f70"},
+    {file = "tokenizers-0.20.0-cp38-none-win32.whl", hash = "sha256:55a393f893d2ed4dd95a1553c2e42d4d4086878266f437b03590d3f81984c4fe"},
+    {file = "tokenizers-0.20.0-cp38-none-win_amd64.whl", hash = "sha256:30ffe33c5c2f2aab8e9a3340d0110dd9f7ace7eec7362e20a697802306bd8068"},
+    {file = "tokenizers-0.20.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:aa2d4a6fed2a7e3f860c7fc9d48764bb30f2649d83915d66150d6340e06742b8"},
+    {file = "tokenizers-0.20.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b5ef0f814084a897e9071fc4a868595f018c5c92889197bdc4bf19018769b148"},
+    {file = "tokenizers-0.20.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc1e1b791e8c3bf4c4f265f180dadaff1c957bf27129e16fdd5e5d43c2d3762c"},
+    {file = "tokenizers-0.20.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b69e55e481459c07885263743a0d3c18d52db19bae8226a19bcca4aaa213fff"},
+    {file = "tokenizers-0.20.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4806b4d82e27a2512bc23057b2986bc8b85824914286975b84d8105ff40d03d9"},
+    {file = "tokenizers-0.20.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9859e9ef13adf5a473ccab39d31bff9c550606ae3c784bf772b40f615742a24f"},
+    {file = "tokenizers-0.20.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef703efedf4c20488a8eb17637b55973745b27997ff87bad88ed499b397d1144"},
+    {file = "tokenizers-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eec0061bab94b1841ab87d10831fdf1b48ebaed60e6d66d66dbe1d873f92bf5"},
+    {file = "tokenizers-0.20.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:980f3d0d7e73f845b69087f29a63c11c7eb924c4ad6b358da60f3db4cf24bdb4"},
+    {file = "tokenizers-0.20.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7c157550a2f3851b29d7fdc9dc059fcf81ff0c0fc49a1e5173a89d533ed043fa"},
+    {file = "tokenizers-0.20.0-cp39-none-win32.whl", hash = "sha256:8a3d2f4d08608ec4f9895ec25b4b36a97f05812543190a5f2c3cd19e8f041e5a"},
+    {file = "tokenizers-0.20.0-cp39-none-win_amd64.whl", hash = "sha256:d90188d12afd0c75e537f9a1d92f9c7375650188ee4f48fdc76f9e38afbd2251"},
+    {file = "tokenizers-0.20.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d68e15f1815357b059ec266062340c343ea7f98f7f330602df81ffa3474b6122"},
+    {file = "tokenizers-0.20.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:23f9ecec637b9bc80da5f703808d29ed5329e56b5aa8d791d1088014f48afadc"},
+    {file = "tokenizers-0.20.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f830b318ee599e3d0665b3e325f85bc75ee2d2ca6285f52e439dc22b64691580"},
+    {file = "tokenizers-0.20.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3dc750def789cb1de1b5a37657919545e1d9ffa667658b3fa9cb7862407a1b8"},
+    {file = "tokenizers-0.20.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e26e6c755ae884c2ea6135cd215bdd0fccafe4ee62405014b8c3cd19954e3ab9"},
+    {file = "tokenizers-0.20.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a1158c7174f427182e08baa2a8ded2940f2b4a3e94969a85cc9cfd16004cbcea"},
+    {file = "tokenizers-0.20.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:6324826287a3fc198898d3dcf758fe4a8479e42d6039f4c59e2cedd3cf92f64e"},
+    {file = "tokenizers-0.20.0-pp37-pypy37_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7d8653149405bb0c16feaf9cfee327fdb6aaef9dc2998349fec686f35e81c4e2"},
+    {file = "tokenizers-0.20.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8a2dc1e402a155e97309287ca085c80eb1b7fab8ae91527d3b729181639fa51"},
+    {file = "tokenizers-0.20.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07bef67b20aa6e5f7868c42c7c5eae4d24f856274a464ae62e47a0f2cccec3da"},
+    {file = "tokenizers-0.20.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da06e397182ff53789c506c7833220c192952c57e1581a53f503d8d953e2d67e"},
+    {file = "tokenizers-0.20.0-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:302f7e11a14814028b7fc88c45a41f1bbe9b5b35fd76d6869558d1d1809baa43"},
+    {file = "tokenizers-0.20.0-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:055ec46e807b875589dfbe3d9259f9a6ee43394fb553b03b3d1e9541662dbf25"},
+    {file = "tokenizers-0.20.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e3144b8acebfa6ae062e8f45f7ed52e4b50fb6c62f93afc8871b525ab9fdcab3"},
+    {file = "tokenizers-0.20.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:b52aa3fd14b2a07588c00a19f66511cff5cca8f7266ca3edcdd17f3512ad159f"},
+    {file = "tokenizers-0.20.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b8cf52779ffc5d4d63a0170fbeb512372bad0dd014ce92bbb9149756c831124"},
+    {file = "tokenizers-0.20.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:983a45dd11a876124378dae71d6d9761822199b68a4c73f32873d8cdaf326a5b"},
+    {file = "tokenizers-0.20.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df6b819c9a19831ebec581e71a7686a54ab45d90faf3842269a10c11d746de0c"},
+    {file = "tokenizers-0.20.0-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e738cfd80795fcafcef89c5731c84b05638a4ab3f412f97d5ed7765466576eb1"},
+    {file = "tokenizers-0.20.0-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:c8842c7be2fadb9c9edcee233b1b7fe7ade406c99b0973f07439985c1c1d0683"},
+    {file = "tokenizers-0.20.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e47a82355511c373a4a430c4909dc1e518e00031207b1fec536c49127388886b"},
+    {file = "tokenizers-0.20.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:9afbf359004551179a5db19424180c81276682773cff2c5d002f6eaaffe17230"},
+    {file = "tokenizers-0.20.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a07eaa8799a92e6af6f472c21a75bf71575de2af3c0284120b7a09297c0de2f3"},
+    {file = "tokenizers-0.20.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0994b2e5fc53a301071806bc4303e4bc3bdc3f490e92a21338146a36746b0872"},
+    {file = "tokenizers-0.20.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b6466e0355b603d10e3cc3d282d350b646341b601e50969464a54939f9848d0"},
+    {file = "tokenizers-0.20.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:1e86594c2a433cb1ea09cfbe596454448c566e57ee8905bd557e489d93e89986"},
+    {file = "tokenizers-0.20.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3e14cdef1efa96ecead6ea64a891828432c3ebba128bdc0596e3059fea104ef3"},
+    {file = "tokenizers-0.20.0.tar.gz", hash = "sha256:39d7acc43f564c274085cafcd1dae9d36f332456de1a31970296a6b8da4eac8d"},
+]
+
+[package.dependencies]
+huggingface-hub = ">=0.16.4,<1.0"
+
+[package.extras]
+dev = ["tokenizers[testing]"]
+docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
+testing = ["black (==22.3)", "datasets", "numpy", "pytest", "requests", "ruff"]
 
 [[package]]
 name = "toml"
@@ -6794,23 +7641,6 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "p
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "urllib3"
-version = "2.2.2"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
-]
-
-[package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-h2 = ["h2 (>=4,<5)"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
 name = "uvloop"
 version = "0.19.0"
 description = "Fast implementation of asyncio event loop on top of libuv"
@@ -6853,6 +7683,21 @@ files = [
 [package.extras]
 docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)"]
 test = ["Cython (>=0.29.36,<0.30.0)", "aiohttp (==3.9.0b0)", "aiohttp (>=3.8.1)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=23.0.0,<23.1.0)", "pycodestyle (>=2.9.0,<2.10.0)"]
+
+[[package]]
+name = "waitress"
+version = "3.0.0"
+description = "Waitress WSGI server"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "waitress-3.0.0-py3-none-any.whl", hash = "sha256:2a06f242f4ba0cc563444ca3d1998959447477363a2d7e9b8b4d75d35cfd1669"},
+    {file = "waitress-3.0.0.tar.gz", hash = "sha256:005da479b04134cdd9dd602d1ee7c49d79de0537610d653674cc6cbde222b8a1"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
+testing = ["coverage (>=5.0)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "wasabi"
@@ -7053,6 +7898,16 @@ files = [
     {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
     {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
     {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ecee4132c6cd2ce5308e21672015ddfed1ff975ad0ac8d27168ea82e71413f55"},
+    {file = "wrapt-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2020f391008ef874c6d9e208b24f28e31bcb85ccff4f335f15a3251d222b92d9"},
+    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2feecf86e1f7a86517cab34ae6c2f081fd2d0dac860cb0c0ded96d799d20b335"},
+    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:240b1686f38ae665d1b15475966fe0472f78e71b1b4903c143a842659c8e4cb9"},
+    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9008dad07d71f68487c91e96579c8567c98ca4c3881b9b113bc7b33e9fd78b8"},
+    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6447e9f3ba72f8e2b985a1da758767698efa72723d5b59accefd716e9e8272bf"},
+    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:acae32e13a4153809db37405f5eba5bac5fbe2e2ba61ab227926a22901051c0a"},
+    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:49ef582b7a1152ae2766557f0550a9fcbf7bbd76f43fbdc94dd3bf07cc7168be"},
+    {file = "wrapt-1.14.1-cp311-cp311-win32.whl", hash = "sha256:358fe87cc899c6bb0ddc185bf3dbfa4ba646f05b1b0b9b5a27c2cb92c2cea204"},
+    {file = "wrapt-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:26046cd03936ae745a502abf44dac702a5e6880b2b01c29aea8ddf3353b68224"},
     {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
     {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
     {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
@@ -7235,4 +8090,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "676e8fda3a28962f955509f254735d998620c4fa6d1f41de649b1f2905545c38"
+content-hash = "ec085e7fb2ae94092a528e3949700c43cce95ea970dac185f12d95ed42b29203"

--- a/poetry.lock
+++ b/poetry.lock
@@ -301,6 +301,63 @@ twisted = ["twisted"]
 zookeeper = ["kazoo"]
 
 [[package]]
+name = "argon2-cffi"
+version = "23.1.0"
+description = "Argon2 for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "argon2_cffi-23.1.0-py3-none-any.whl", hash = "sha256:c670642b78ba29641818ab2e68bd4e6a78ba53b7eff7b4c3815ae16abf91c7ea"},
+    {file = "argon2_cffi-23.1.0.tar.gz", hash = "sha256:879c3e79a2729ce768ebb7d36d4609e3a78a4ca2ec3a9f12286ca057e3d0db08"},
+]
+
+[package.dependencies]
+argon2-cffi-bindings = "*"
+
+[package.extras]
+dev = ["argon2-cffi[tests,typing]", "tox (>4)"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-copybutton", "sphinx-notfound-page"]
+tests = ["hypothesis", "pytest"]
+typing = ["mypy"]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "21.2.0"
+description = "Low-level CFFI bindings for Argon2"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "argon2-cffi-bindings-21.2.0.tar.gz", hash = "sha256:bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ccb949252cb2ab3a08c02024acb77cfb179492d5701c7cbdbfd776124d4d2367"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9524464572e12979364b7d600abf96181d3541da11e23ddf565a32e70bd4dc0d"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b746dba803a79238e925d9046a63aa26bf86ab2a2fe74ce6b009a1c3f5c8f2ae"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58ed19212051f49a523abb1dbe954337dc82d947fb6e5a0da60f7c8471a8476c"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:bd46088725ef7f58b5a1ef7ca06647ebaf0eb4baff7d1d0d177c6cc8744abd86"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_i686.whl", hash = "sha256:8cd69c07dd875537a824deec19f978e0f2078fdda07fd5c42ac29668dda5f40f"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f1152ac548bd5b8bcecfb0b0371f082037e47128653df2e8ba6e914d384f3c3e"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-win32.whl", hash = "sha256:603ca0aba86b1349b147cab91ae970c63118a0f30444d4bc80355937c950c082"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-win_amd64.whl", hash = "sha256:b2ef1c30440dbbcba7a5dc3e319408b59676e2e039e2ae11a8775ecf482b192f"},
+    {file = "argon2_cffi_bindings-21.2.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e415e3f62c8d124ee16018e491a009937f8cf7ebf5eb430ffc5de21b900dad93"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3e385d1c39c520c08b53d63300c3ecc28622f076f4c2b0e6d7e796e9f6502194"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c3e3cc67fdb7d82c4718f19b4e7a87123caf8a93fde7e23cf66ac0337d3cb3f"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a22ad9800121b71099d0fb0a65323810a15f2e292f2ba450810a7316e128ee5"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f9f8b450ed0547e3d473fdc8612083fd08dd2120d6ac8f73828df9b7d45bb351"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:93f9bf70084f97245ba10ee36575f0c3f1e7d7724d67d8e5b08e61787c320ed7"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3b9ef65804859d335dc6b31582cad2c5166f0c3e7975f324d9ffaa34ee7e6583"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4966ef5848d820776f5f562a7d45fdd70c2f330c961d0d745b784034bd9f48d"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20ef543a89dee4db46a1a6e206cd015360e5a75822f76df533845c3cbaf72670"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2937d286e2ad0cc79a7087d3c272832865f779430e0cc2b4f3718d3159b0cb"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:5e00316dabdaea0b2dd82d141cc66889ced0cdcbfa599e8b471cf22c620c329a"},
+]
+
+[package.dependencies]
+cffi = ">=1.0.1"
+
+[package.extras]
+dev = ["cogapp", "pre-commit", "pytest", "wheel"]
+tests = ["pytest"]
+
+[[package]]
 name = "astunparse"
 version = "1.6.3"
 description = "An AST unparser for Python"
@@ -512,41 +569,44 @@ numpy = [
 
 [[package]]
 name = "boto3"
-version = "1.27.1"
+version = "1.35.8"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.27.1-py3-none-any.whl", hash = "sha256:0085c1066953e61915b34f24fbdee7117fd2d8b5c9188b9519d47ba84510c067"},
-    {file = "boto3-1.27.1.tar.gz", hash = "sha256:cf43deb4556295219d9de44d1c95921209c90ee25246673b5768aef9d46519cc"},
+    {file = "boto3-1.35.8-py3-none-any.whl", hash = "sha256:06eac4757de2a9c6020381205cb902f05964caad80b56e58c8931284a133b4cb"},
+    {file = "boto3-1.35.8.tar.gz", hash = "sha256:b9587131372a808bf6f99c5ed8b11be55cd113261cc3b437a917b4acc6c30bfe"},
 ]
 
 [package.dependencies]
-botocore = ">=1.30.1,<1.31.0"
+botocore = ">=1.35.8,<1.36.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.6.0,<0.7.0"
+s3transfer = ">=0.10.0,<0.11.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.30.1"
+version = "1.35.8"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.30.1-py3-none-any.whl", hash = "sha256:18a32a21bfa9b418b9a38ea5ef4464eba003cbb26fca2cd56e4f51098c5d1a0f"},
-    {file = "botocore-1.30.1.tar.gz", hash = "sha256:4d1ac5a796c5c5c87946f25f3d98764288a0ed848e772a7a47cd134847e885e7"},
+    {file = "botocore-1.35.8-py3-none-any.whl", hash = "sha256:adf389eb8fd87775f193300e3431d1353f925807ad3a39958172cb644f0d60a1"},
+    {file = "botocore-1.35.8.tar.gz", hash = "sha256:4b820cf680ab5d778bd2fe4feeef1ff8a2b96d5c535d4638ab30f703ade282f8"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = ">=1.25.4,<1.27"
+urllib3 = [
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+]
 
 [package.extras]
-crt = ["awscrt (==0.16.9)"]
+crt = ["awscrt (==0.21.2)"]
 
 [[package]]
 name = "cachecontrol"
@@ -3054,13 +3114,13 @@ files = [
 
 [[package]]
 name = "litellm"
-version = "1.43.19"
+version = "1.44.9"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 files = [
-    {file = "litellm-1.43.19-py3-none-any.whl", hash = "sha256:f66bfe9c8b91577af57a5d1203728abc9b59df38a545148b7e85dec903185c12"},
-    {file = "litellm-1.43.19.tar.gz", hash = "sha256:b1f475f98073632f0cea6d814bb10b14b6498e5ff93b91b52dfc00445bf013ab"},
+    {file = "litellm-1.44.9-py3-none-any.whl", hash = "sha256:457c5d085233bfcbe81f106ca109ed822676445a610ff8330240fa605741cb02"},
+    {file = "litellm-1.44.9.tar.gz", hash = "sha256:54e9b25a0dd30b7ae33bdaf3fe04acf779a6ba6ac9551bcf5d8bb3749ae8cd13"},
 ]
 
 [package.dependencies]
@@ -3077,8 +3137,8 @@ tiktoken = ">=0.7.0"
 tokenizers = "*"
 
 [package.extras]
-extra-proxy = ["azure-identity (>=1.15.0,<2.0.0)", "azure-keyvault-secrets (>=4.8.0,<5.0.0)", "google-cloud-kms (>=2.21.3,<3.0.0)", "prisma (==0.11.0)", "pynacl (>=1.5.0,<2.0.0)", "resend (>=0.8.0,<0.9.0)"]
-proxy = ["PyJWT (>=2.8.0,<3.0.0)", "apscheduler (>=3.10.4,<4.0.0)", "backoff", "cryptography (>=42.0.5,<43.0.0)", "fastapi (>=0.111.0,<0.112.0)", "fastapi-sso (>=0.10.0,<0.11.0)", "gunicorn (>=22.0.0,<23.0.0)", "orjson (>=3.9.7,<4.0.0)", "python-multipart (>=0.0.9,<0.0.10)", "pyyaml (>=6.0.1,<7.0.0)", "rq", "uvicorn (>=0.22.0,<0.23.0)"]
+extra-proxy = ["azure-identity (>=1.15.0,<2.0.0)", "azure-keyvault-secrets (>=4.8.0,<5.0.0)", "google-cloud-kms (>=2.21.3,<3.0.0)", "prisma (==0.11.0)", "resend (>=0.8.0,<0.9.0)"]
+proxy = ["PyJWT (>=2.8.0,<3.0.0)", "apscheduler (>=3.10.4,<4.0.0)", "backoff", "cryptography (>=42.0.5,<43.0.0)", "fastapi (>=0.111.0,<0.112.0)", "fastapi-sso (>=0.10.0,<0.11.0)", "gunicorn (>=22.0.0,<23.0.0)", "orjson (>=3.9.7,<4.0.0)", "pynacl (>=1.5.0,<2.0.0)", "python-multipart (>=0.0.9,<0.0.10)", "pyyaml (>=6.0.1,<7.0.0)", "rq", "uvicorn (>=0.22.0,<0.23.0)"]
 
 [[package]]
 name = "locket"
@@ -3436,16 +3496,22 @@ files = [
 ]
 
 [[package]]
-name = "milvus-lite"
-version = "2.4.7"
-description = "A lightweight version of Milvus wrapped with Python."
+name = "minio"
+version = "7.2.8"
+description = "MinIO Python SDK for Amazon S3 Compatible Cloud Storage"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">3.8"
 files = [
-    {file = "milvus_lite-2.4.7-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:c828190118b104b05b8c8e0b5a4147811c86b54b8fb67bc2e726ad10fc0b544e"},
-    {file = "milvus_lite-2.4.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e1537633c39879714fb15082be56a4b97f74c905a6e98e302ec01320561081af"},
-    {file = "milvus_lite-2.4.7-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f016474d663045787dddf1c3aad13b7d8b61fd329220318f858184918143dcbf"},
+    {file = "minio-7.2.8-py3-none-any.whl", hash = "sha256:aa3b485788b63b12406a5798465d12a57e4be2ac2a58a8380959b6b748e64ddd"},
+    {file = "minio-7.2.8.tar.gz", hash = "sha256:f8af2dafc22ebe1aef3ac181b8e217037011c430aa6da276ed627e55aaf7c815"},
 ]
+
+[package.dependencies]
+argon2-cffi = "*"
+certifi = "*"
+pycryptodome = "*"
+typing-extensions = "*"
+urllib3 = "*"
 
 [[package]]
 name = "ml-dtypes"
@@ -4967,29 +5033,32 @@ python-dateutil = ">=2.8.0"
 
 [[package]]
 name = "pymilvus"
-version = "2.4.4"
+version = "2.4.1"
 description = "Python Sdk for Milvus"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pymilvus-2.4.4-py3-none-any.whl", hash = "sha256:073b76bc36f6f4e70f0f0a0023a53324f0ba8ef9a60883f87cd30a44b6c6f2b5"},
-    {file = "pymilvus-2.4.4.tar.gz", hash = "sha256:50c53eb103e034fbffe936fe942751ea3dbd2452e18cf79acc52360ed4987fb7"},
+    {file = "pymilvus-2.4.1-py3-none-any.whl", hash = "sha256:1ad85c011e56b40944b224c34ad5c1565fe5ac703589986d323b9fd7ad3973bf"},
+    {file = "pymilvus-2.4.1.tar.gz", hash = "sha256:e77ceb3459d4574685fa3e346c4608354272b50b16a2d65fb7928068184a1ab7"},
 ]
 
 [package.dependencies]
+azure-storage-blob = "*"
 environs = "<=9.5.0"
-grpcio = ">=1.49.1,<=1.63.0"
-milvus-lite = {version = ">=2.4.0,<2.5.0", markers = "sys_platform != \"win32\""}
+grpcio = ">=1.49.1,<=1.60.0"
+minio = ">=7.0.0"
 numpy = {version = "<1.25.0", markers = "python_version <= \"3.8\""}
 pandas = ">=1.2.4"
 protobuf = ">=3.20.0"
+pyarrow = ">=12.0.0"
+requests = "*"
+scipy = "*"
 setuptools = ">=67"
 ujson = ">=2.0.0"
 
 [package.extras]
-bulk-writer = ["azure-storage-blob", "minio (>=7.0.0)", "pyarrow (>=12.0.0)", "requests"]
-dev = ["black", "grpcio (==1.62.2)", "grpcio-testing (==1.62.2)", "grpcio-tools (==1.62.2)", "pytest (>=5.3.4)", "pytest-cov (>=2.8.1)", "pytest-timeout (>=1.3.4)", "ruff (>0.4.0)"]
 model = ["milvus-model (>=0.1.0)"]
+test = ["black", "grpcio-testing", "pytest (>=5.3.4)", "pytest-cov (>=2.8.1)", "pytest-timeout (>=1.3.4)", "ruff (>=0.3.3)"]
 
 [[package]]
 name = "pymongo"
@@ -5439,13 +5508,13 @@ fire = "*"
 
 [[package]]
 name = "rasa-pro"
-version = "3.10.0rc1"
+version = "3.10.0rc2"
 description = "State-of-the-art open-core Conversational AI framework for Enterprises that natively leverages generative AI for effortless assistant development."
 optional = false
 python-versions = ">=3.8.1,<3.11"
 files = [
-    {file = "rasa_pro-3.10.0rc1-py3-none-any.whl", hash = "sha256:99443f0e47a5bf460700c7ad5e5e9b479855fb04627640db03c1466356463fd1"},
-    {file = "rasa_pro-3.10.0rc1.tar.gz", hash = "sha256:eb4406f53530ee0a66f947983134b63abf29edbfc6a428847250c17190011b73"},
+    {file = "rasa_pro-3.10.0rc2-py3-none-any.whl", hash = "sha256:3b62c87ac08a7f40a742e63ef7dabd1455c06b3757d74dd47329b9381daadd85"},
+    {file = "rasa_pro-3.10.0rc2.tar.gz", hash = "sha256:b3e83207c5f3fe6c40741168376d48687003550f469d293c2265f66c6c82cabf"},
 ]
 
 [package.dependencies]
@@ -5456,7 +5525,7 @@ aiohttp = ">=3.9.4,<3.10"
 apscheduler = ">=3.10,<3.11"
 attrs = ">=23.1,<23.2"
 azure-storage-blob = ">=12.16.0,<12.17.0"
-boto3 = ">=1.27.1,<1.28.0"
+boto3 = ">=1.35.5,<1.36.0"
 CacheControl = ">=0.12.14,<0.13.0"
 certifi = ">=2024.2.2"
 cloudpickle = ">=2.2.1,<3.1"
@@ -5485,7 +5554,7 @@ jsonpickle = ">=3.0,<3.1"
 jsonschema = ">=4.22"
 langchain = ">=0.2.0,<0.3.0"
 langchain-community = ">=0.2.0,<0.3.0"
-litellm = ">=1.43.6,<2.0.0"
+litellm = ">=1.44.7,<1.45.0"
 matplotlib = ">=3.7,<3.8"
 mattermostwrapper = ">=2.2,<2.3"
 mlflow = {version = ">=2.15.1,<3.0.0", optional = true, markers = "extra == \"mlflow\""}
@@ -5512,7 +5581,7 @@ pydantic = ">=2.0,<3.0"
 pydot = ">=1.4,<1.5"
 PyJWT = {version = ">=2.8.0,<3.0.0", extras = ["crypto"]}
 pykwalify = ">=1.8,<1.9"
-pymilvus = ">=2.3.6,<3.0.0"
+pymilvus = "<2.4.2"
 pymongo = {version = ">=4.6.3,<4.7", extras = ["srv", "tls"]}
 pypred = ">=0.4.0,<0.5.0"
 python-dateutil = ">=2.8.2,<2.9.0"
@@ -5525,7 +5594,7 @@ pyyaml = ">=6.0"
 qdrant-client = ">=1.9.0,<2.0.0"
 questionary = ">=1.10.0,<2.1.0"
 randomname = ">=0.2.1,<0.3.0"
-rasa-sdk = "3.10.0rc1"
+rasa-sdk = "3.10.0rc2"
 redis = ">=4.6.0,<6.0"
 regex = ">=2022.10.31,<2022.11"
 requests = ">=2.31.0,<2.32.0"
@@ -5585,13 +5654,13 @@ reference = "rasa-pro"
 
 [[package]]
 name = "rasa-sdk"
-version = "3.10.0rc1"
+version = "3.10.0rc2"
 description = "Open source machine learning framework to automate text- and voice-based conversations: NLU, dialogue management, connect to Slack, Facebook, and more - Create chatbots and voice assistants"
 optional = false
 python-versions = "<3.11,>=3.8"
 files = [
-    {file = "rasa_sdk-3.10.0rc1-py3-none-any.whl", hash = "sha256:05ad3566d8ff2dc3fca392aeeb2f340a211b41b4e08b5f6881aaa4e4464a75db"},
-    {file = "rasa_sdk-3.10.0rc1.tar.gz", hash = "sha256:2b4b85a858481a936dbfffe01e91bcbb94eaec59e751473c84b2ae41987bac9d"},
+    {file = "rasa_sdk-3.10.0rc2-py3-none-any.whl", hash = "sha256:8d8ed44cd61c05fe374c95737c19e06f13502c5c9ce6dcb738da55399c3bd04a"},
+    {file = "rasa_sdk-3.10.0rc2.tar.gz", hash = "sha256:7465a2a996d1761e064044f50a76488a2ffce7a8fcac180dd90dc23d8ccda6a4"},
 ]
 
 [package.dependencies]
@@ -6045,20 +6114,20 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.6.2"
+version = "0.10.2"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "s3transfer-0.6.2-py3-none-any.whl", hash = "sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084"},
-    {file = "s3transfer-0.6.2.tar.gz", hash = "sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861"},
+    {file = "s3transfer-0.10.2-py3-none-any.whl", hash = "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"},
+    {file = "s3transfer-0.10.2.tar.gz", hash = "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6"},
 ]
 
 [package.dependencies]
-botocore = ">=1.12.36,<2.0a.0"
+botocore = ">=1.33.2,<2.0a.0"
 
 [package.extras]
-crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
 name = "sanic"
@@ -8090,4 +8159,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "ec085e7fb2ae94092a528e3949700c43cce95ea970dac185f12d95ed42b29203"
+content-hash = "48dec83b524cc7d32e6c213ea1f484785d401a4b6c496a16885fb6cc69b51a7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ priority = "supplemental"
 python = ">=3.8.1,<3.11"
 
 [tool.poetry.dependencies.rasa-pro]
-version = "3.10.0"
+version = "3.10.1"
 allow-prereleases = true
 extras = ["mlflow"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,9 @@ priority = "supplemental"
 python = ">=3.8.1,<3.11"
 
 [tool.poetry.dependencies.rasa-pro]
-version = "3.9.3"
+version = "3.10.0rc1"
 allow-prereleases = true
+extras = ["mlflow"]
 
 [tool.poetry.group.dev.dependencies]
 toml = "^0.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ priority = "supplemental"
 python = ">=3.8.1,<3.11"
 
 [tool.poetry.dependencies.rasa-pro]
-version = "3.10.0rc2"
+version = "3.10.0rc3"
 allow-prereleases = true
 extras = ["mlflow"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ priority = "supplemental"
 python = ">=3.8.1,<3.11"
 
 [tool.poetry.dependencies.rasa-pro]
-version = "3.10.0rc3"
+version = "3.10.0"
 allow-prereleases = true
 extras = ["mlflow"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ priority = "supplemental"
 python = ">=3.8.1,<3.11"
 
 [tool.poetry.dependencies.rasa-pro]
-version = "3.10.0rc1"
+version = "3.10.0rc2"
 allow-prereleases = true
 extras = ["mlflow"]
 


### PR DESCRIPTION
## Description
Update `rasa-calm-demo`'s `main` branch to version `3.10.1`, now that PR #57 is included in this branch `release-3.10`.

## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)
