### PR TITLE
Fix tag model step in CI workflow for `main` branch

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -90,7 +90,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           curl --request PUT \
-          --url "${{secrets.RASA_X_DEPLOYMENT}}/api/projects/default/models/${{steps.upload_model.outputs.model}}/tags/production?api_token=${{secrets.RASA_X_TOKEN}} \
+          --url "${{secrets.RASA_X_DEPLOYMENT}}/api/projects/default/models/${{steps.upload_model.outputs.model}}/tags/production?api_token=${{secrets.RASA_X_TOKEN}}" \
           --header 'content-type: application/json'
 
       - name: Persist model


### PR DESCRIPTION
## Description
Fix tag model step in CI workflow for `main` branch. Just a one character change:

1. Saw that `Tag model as production` step on `main` was [failing](https://github.com/RasaHQ/rasa-calm-demo/actions/runs/10921775550/job/30314989016#step:14:89)
2. Due to [missing closing quote](https://github.com/RasaHQ/rasa-calm-demo/actions/runs/10921775550/job/30314989016#step:14:90) in the curl command
3. ...so [added the missing closing quote](https://github.com/RasaHQ/rasa-calm-demo/pull/59/files#diff-33b53b32f50aa98dc8f70274e80f6db68f4a807d1c75cafebc1370c2de296bd6R93)

Also, noticed the CI pipeline had been failing on `main` since beginning due to this issue:
```
gh run list --workflow continous-integration.yml --branch main
STATUS  TITLE                                                                   WORKFLOW                              BRANCH  EVENT  ID           ELAPSED  AGE                 
X       ENG-1293: Update rasa-calm-demo to version 3.10.1 (#58)                 Continous Integration and Deployment  main    push   10921775550  6m17s    about 33 minutes ago
X       Separate feature configurations (#42)                                   Continous Integration and Deployment  main    push   10112691035  5m1s     about 1 month ago
X       Removed unnecessary test for chitchat response at the end of another …  Continous Integration and Deployment  main    push   10003915989  5m6s     about 2 months ago
X       Merge pull request #40 from RasaHQ/qdrant-instructions                  Continous Integration and Deployment  main    push   9906813443   5m56s    about 2 months ago
X       Merge pull request #39 from RasaHQ/release-3.9                          Continous Integration and Deployment  main    push   9854050685   5m12s    about 2 months ago
X       Merge pull request #25 from RasaHQ/fix-test-run-schedule                Continous Integration and Deployment  main    push   9763077548   2m50s    about 2 months ago
X       Merge pull request #27 from RasaHQ/replace-card-using-call              Continous Integration and Deployment  main    push   9577602521   2m56s    about 3 months ago
X       Merge pull request #28 from RasaHQ/update-readme-makefile               Continous Integration and Deployment  main    push   9571996187   2m47s    about 3 months ago
X       Merge pull request #26 from RasaHQ/ENG-876-consistency-feature-comple…  Continous Integration and Deployment  main    push   9549819809   2m46s    about 3 months ago
X       Merge pull request #24 from RasaHQ/fix-test-run-schedule                Continous Integration and Deployment  main    push   9417429074   6m15s    about 3 months ago
X       Merge pull request #23 from RasaHQ/ATO-1037                             Continous Integration and Deployment  main    push   9205596678   2m23s    about 3 months ago
X       Merge pull request #20 from RasaHQ/update_rasa_version                  Continous Integration and Deployment  main    push   8736407337   2m4s     about 5 months ago
X       Merge pull request #15 from RasaHQ/sec-217                              Continous Integration and Deployment  main    push   8375308518   2m31s    about 6 months ago
X       Merge pull request #6 from RasaHQ/ENG-766-test-fixes-multi-prompting-…  Continous Integration and Deployment  main    push   8172045163   2m27s    about 6 months ago
X       Update rasa and rasa-plus to 3.7.8 (#11)                                Continous Integration and Deployment  main    push   8138146467   2m35s    about 6 months ago
X       Merge pull request #9 from RasaHQ/ENG-814-add-additional-prompts        Continous Integration and Deployment  main    push   8100773363   2m32s    about 6 months ago
X       Add info about setting up RASA_DUCKLING_HTTP_URL environment variable…  Continous Integration and Deployment  main    push   7901392994   2m27s    about 7 months ago
X       Move duckling loading to its own module (#7)                            Continous Integration and Deployment  main    push   7801559856   2m38s    about 7 months ago
X       Merge pull request #4 from RasaHQ/fix-makefile-rasa-inspect             Continous Integration and Deployment  main    push   7657210391   37s      about 7 months ago
X       Update README.md                                                        Continous Integration and Deployment  main    push   7639881280   34s      about 7 months ago
```

## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)
