### PR TITLE
Demonstrate linking a pattern_chitchat from other pattern (in this case pattern_cannot_handle)

### DIFF
--- a/data/flows/patterns.yml
+++ b/data/flows/patterns.yml
@@ -102,7 +102,7 @@ flows:
           - if: context.reason is "cannot_handle_chitchat"
             then:
               - action: utter_cannot_handle
-                next: "END"
+                next: END
           # Fallback for things that are not supported
           - if: context.reason is "cannot_handle_not_supported"
             then:


### PR DESCRIPTION
## Description
This PR demonstrates linking a `pattern_chitchat` from another pattern, specifically `pattern_cannot_handle`, as requested in this [PR](https://github.com/RasaHQ/rasa-private/pull/2647#pullrequestreview-2923453941) on `rasa-private`.

## TODOs
- [ ] compared flaky tests with the [known list of flaky tests steps](https://www.notion.so/rasa/Flaky-E2E-Test-Steps-63864d3d8c7b4427a0f3df8052e39f21)
